### PR TITLE
Add documentation for UI and chat components

### DIFF
--- a/docs/Button.md
+++ b/docs/Button.md
@@ -1,0 +1,34 @@
+# Button
+
+## Purpose
+- Generic styled button used across the UI.
+- Supports different sizes, colors and a loading spinner.
+
+## Props
+| Prop | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| `variant` | `'primary' \| 'secondary' \| 'danger' \| 'ghost'` | No | Visual style. |
+| `size` | `'sm' \| 'md' \| 'lg'` | No | Button padding and font size. |
+| `loading` | `boolean` | No | Shows a spinner and disables clicks. |
+| `...` | `ButtonHTMLAttributes<HTMLButtonElement>` | No | Any normal button props. |
+
+## State Variables
+- None
+
+## useEffect Hooks
+- None
+
+## Event Handlers
+- None (uses native `onClick` passed in props).
+
+## Data Flow
+- Displays children and optionally a spinner when `loading` is true.
+
+## Usage Locations
+- `components/ui/ModelDetailsSidebar.tsx`
+- `components/ui/ModelComparison.tsx`
+- `components/ui/ChatSidebar.tsx`
+- `components/ui/ErrorBoundary.tsx`
+
+## Notes for Juniors
+- When `loading` is true the button becomes disabled to prevent extra clicks.

--- a/docs/ChatInterface.md
+++ b/docs/ChatInterface.md
@@ -1,0 +1,48 @@
+# ChatInterface
+
+## Purpose
+- Renders the main chat area with model selection and sidebars.
+- Coordinates chat messages, model details, and responsive layout.
+
+## Props
+| Prop | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| – | – | – | This component does not accept props. |
+
+## State Variables
+- `selectedDetailModel`: `null` – model shown in the details sidebar.
+- `isDetailsSidebarOpen`: `false` – whether the model details sidebar is visible on mobile.
+- `isChatSidebarOpen`: `false` – open state of the chat history sidebar on mobile.
+- `selectedTab`: `'overview'` – active tab in the model details sidebar.
+- `selectedGenerationId`: `undefined` – generation ID to load pricing/capabilities info.
+- `hoveredGenerationId`: `undefined` – highlights a message when hovering a generation ID.
+- `scrollToCompletionId`: `undefined` – triggers scroll to a specific message.
+
+## useEffect Hooks
+- None in this component.
+
+## Event Handlers
+- `handleRetry` – retries the last user message when the error banner’s Retry button is clicked.
+- `handleShowDetails` – opens model details for a model picked from the dropdown.
+- `handleModelSelect` – updates `selectedModel` and shows details when a model is chosen.
+- `handleCloseDetailsSidebar` – hides the details sidebar and clears the selected model info.
+- `handleModelClickFromMessage` – opens details when the user clicks a model name in a message.
+- `handleGenerationHover` – highlights a message when hovering a generation ID.
+- `handleGenerationClick` – scrolls to a message associated with a generation ID.
+- `handleNewChat` – reloads the page to start a new conversation.
+- `handleToggleChatSidebar` – toggles the chat history sidebar on mobile.
+
+## Data Flow
+- Fetches messages and error state from `useChat`.
+- Gets available models and the current model from `useModelSelection`.
+- Passes messages to `MessageList` and handles sending via `MessageInput`.
+- Selected model and details are shared with `ModelDropdown` and `ModelDetailsSidebar`.
+- Errors are displayed through `ErrorDisplay` with the ability to retry.
+
+## Usage Locations
+- `src/app/chat/page.tsx`
+
+## Notes for Juniors
+- `handleNewChat` simply reloads the page; in a real app you might clear state instead.
+- The details sidebar auto-opens on desktop using `window.matchMedia('(min-width: 768px)')`.
+- When resending a message via `handleRetry`, the original failed message’s error flag is cleared.

--- a/docs/ChatSidebar.md
+++ b/docs/ChatSidebar.md
@@ -1,0 +1,36 @@
+# ChatSidebar
+
+## Purpose
+- Mobile-friendly panel listing previous chat sessions.
+- Allows creating, editing and deleting chat titles.
+
+## Props
+| Prop | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| `isOpen` | `boolean` | Yes | Whether the sidebar is visible. |
+| `onClose` | `() => void` | Yes | Called when the user closes the sidebar. |
+| `onNewChat` | `() => void` | Yes | Triggered by the New Chat button. |
+| `className` | `string` | No | Extra CSS classes.
+
+## State Variables
+- `chatHistory`: sample chats list used for the sidebar.
+- `editingId`: `null` – ID of the chat currently being renamed.
+- `editTitle`: `""` – text for the new title.
+
+## useEffect Hooks
+- None
+
+## Event Handlers
+- `handleStartEdit` – begins renaming a chat.
+- `handleSaveEdit` – applies the edited title.
+- `handleCancelEdit` – exits edit mode without saving.
+- `handleDeleteChat` – removes a chat from the list.
+
+## Data Flow
+- Maintains local chat history and displays it with edit controls.
+
+## Usage Locations
+- `components/chat/ChatInterface.tsx`
+
+## Notes for Juniors
+- The chat history here is mock data; in a real app you would load it from storage.

--- a/docs/ErrorBoundary.md
+++ b/docs/ErrorBoundary.md
@@ -1,0 +1,30 @@
+# ErrorBoundary
+
+## Purpose
+- Catches JavaScript errors in the component tree.
+- Shows a fallback UI and lets users retry or refresh.
+
+## Props
+| Prop | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| `children` | `ReactNode` | Yes | Elements wrapped by the boundary. |
+| `fallback` | `ComponentType<{ error?: Error; retry: () => void }>` | No | Custom UI when an error occurs. |
+
+## State Variables
+- `hasError`: `false` – whether an error has been caught.
+- `error`: `undefined` – error object captured.
+
+## useEffect Hooks
+- None (class component uses lifecycle methods instead).
+
+## Event Handlers
+- `retry` – resets the error state so children re-render.
+
+## Data Flow
+- Uses `getDerivedStateFromError` and `componentDidCatch` to handle errors.
+
+## Usage Locations
+- `src/app/layout.tsx`
+
+## Notes for Juniors
+- Wrap large sections of your app in this boundary to prevent white screens.

--- a/docs/ErrorDisplay.md
+++ b/docs/ErrorDisplay.md
@@ -1,0 +1,36 @@
+# ErrorDisplay
+
+## Purpose
+- Shows an error, warning or info banner with optional actions.
+- Used to present friendly messages and retry options.
+
+## Props
+| Prop | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| `title` | `string` | No | Short heading for the message. |
+| `message` | `string` | Yes | Detailed text to show. |
+| `type` | `'error' \| 'warning' \| 'info'` | No | Visual style of the banner. |
+| `actionButton` | `ReactNode` | No | Additional custom button. |
+| `onRetry` | `() => void` | No | Called when the Try Again link is clicked. |
+| `onClose` | `() => void` | No | Dismisses the banner. |
+| `suggestions` | `string[]` | No | Bulleted suggestions for fixing the error. |
+| `retryAfter` | `number` | No | Seconds before retry is recommended. |
+| `code` | `string` | No | Error code for special handling. |
+
+## State Variables
+- None
+
+## useEffect Hooks
+- None
+
+## Event Handlers
+- `onRetry` and `onClose` passed from the parent component.
+
+## Data Flow
+- Renders an icon and message based on `type` and displays any suggestions.
+
+## Usage Locations
+- `components/chat/ChatInterface.tsx`
+
+## Notes for Juniors
+- Retry countdown is shown only for rate limit errors (`code === 'too_many_requests'`).

--- a/docs/Input.md
+++ b/docs/Input.md
@@ -1,0 +1,31 @@
+# Input
+
+## Purpose
+- Small wrapper around `<input>` with label, helper text and error display.
+- Supports forwarding refs for form libraries.
+
+## Props
+| Prop | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| `label` | `string` | No | Label text above the field. |
+| `error` | `string` | No | Error message shown in red. |
+| `helperText` | `string` | No | Additional hint below the input. |
+| `...` | `InputHTMLAttributes<HTMLInputElement>` | No | All standard input props. |
+
+## State Variables
+- None
+
+## useEffect Hooks
+- None
+
+## Event Handlers
+- None
+
+## Data Flow
+- Passes props straight to the underlying `<input>` element.
+
+## Usage Locations
+- Not referenced elsewhere in the repo.
+
+## Notes for Juniors
+- The `id` is auto-generated if you don't supply one.

--- a/docs/Loading.md
+++ b/docs/Loading.md
@@ -1,0 +1,30 @@
+# Loading
+
+## Purpose
+- Reusable loading indicator with spinner, dots or skeleton variants.
+- Useful while waiting for async data.
+
+## Props
+| Prop | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| `size` | `'sm' \| 'md' \| 'lg'` | No | Control icon dimensions. |
+| `text` | `string` | No | Optional label below the indicator. |
+| `variant` | `'spinner' \| 'skeleton' \| 'dots'` | No | Type of loading animation. |
+
+## State Variables
+- None
+
+## useEffect Hooks
+- None
+
+## Event Handlers
+- None
+
+## Data Flow
+- Renders different markup depending on the chosen `variant`.
+
+## Usage Locations
+- Not referenced elsewhere in the repo.
+
+## Notes for Juniors
+- The skeleton variant shows placeholder bars instead of an icon.

--- a/docs/MarkdownComponents.md
+++ b/docs/MarkdownComponents.md
@@ -1,0 +1,29 @@
+# MarkdownComponents
+
+## Purpose
+- Provides styled elements used when rendering markdown content.
+- Includes code blocks with copy buttons, tables, blockquotes and links.
+
+## Props
+| Prop | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| various | – | – | Each export has its own simple props mirroring HTML tags. |
+
+## State Variables
+- `copied` in `CustomPreBlock`: `false` – shows a "Copied" message when code is copied.
+
+## useEffect Hooks
+- None
+
+## Event Handlers
+- `handleCopy` in `CustomPreBlock` – copies the code text to the clipboard.
+
+## Data Flow
+- Used by `MarkdownRenderer` and `MessageList` to render markdown elements with extra UI.
+
+## Usage Locations
+- `components/chat/MarkdownRenderer.tsx`
+- `components/chat/MessageList.tsx`
+
+## Notes for Juniors
+- These components are basic wrappers around regular HTML elements with Tailwind styles.

--- a/docs/MarkdownRenderer.md
+++ b/docs/MarkdownRenderer.md
@@ -1,0 +1,29 @@
+# MarkdownRenderer
+
+## Purpose
+- Converts markdown text into formatted HTML.
+- Applies GitHub-flavored markdown and code highlighting.
+
+## Props
+| Prop | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| `content` | `string` | Yes | Markdown string to display. |
+
+## State Variables
+- None
+
+## useEffect Hooks
+- None
+
+## Event Handlers
+- None
+
+## Data Flow
+- Uses `ReactMarkdown` with `remark-gfm` and `rehype-highlight`.
+- Custom components from `MarkdownComponents` handle code blocks and tables.
+
+## Usage Locations
+- `components/chat/MessageContent.tsx`
+
+## Notes for Juniors
+- Wrapped in `React.memo` to avoid re-rendering when content does not change.

--- a/docs/MessageContent.md
+++ b/docs/MessageContent.md
@@ -1,0 +1,29 @@
+# MessageContent
+
+## Purpose
+- Displays the content of a single chat message.
+- Lazily loads the markdown renderer when needed for markdown messages.
+
+## Props
+| Prop | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| `message` | `ChatMessage` | Yes | Message data to render. |
+
+## State Variables
+- None
+
+## useEffect Hooks
+- None
+
+## Event Handlers
+- None
+
+## Data Flow
+- Receives a `ChatMessage` and renders markdown through `MarkdownRenderer` if `message.contentType` is `markdown`.
+- Falls back to a plain paragraph for text content.
+
+## Usage Locations
+- Not referenced by other components in this repo.
+
+## Notes for Juniors
+- Uses `React.lazy` and `Suspense` so the markdown renderer is loaded only when needed.

--- a/docs/MessageInput.md
+++ b/docs/MessageInput.md
@@ -1,0 +1,31 @@
+# MessageInput
+
+## Purpose
+- Text area for the user to compose and send a message.
+- Triggers `onSendMessage` when Enter is pressed or the send button is clicked.
+
+## Props
+| Prop | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| `onSendMessage` | `(msg: string) => void` | Yes | Called with the trimmed text. |
+| `disabled` | `boolean` | No | Disables input and shows a spinner. |
+
+## State Variables
+- `message`: `""` – current text in the textarea.
+
+## useEffect Hooks
+- None
+
+## Event Handlers
+- `handleSend` – sends the message and clears the field.
+- `handleKeyPress` – submits on Enter unless Shift is held.
+- `onInput` – auto-resizes the textarea height.
+
+## Data Flow
+- Sends the entered text upward via `onSendMessage`.
+
+## Usage Locations
+- `components/chat/ChatInterface.tsx`
+
+## Notes for Juniors
+- Prevent the default Enter behavior so the form does not submit or add a new line.

--- a/docs/MessageList.md
+++ b/docs/MessageList.md
@@ -1,0 +1,35 @@
+# MessageList
+
+## Purpose
+- Shows the entire conversation thread with copy and scroll helpers.
+- Handles markdown rendering and message highlighting.
+
+## Props
+| Prop | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| `messages` | `ChatMessage[]` | Yes | Messages to display. |
+| `isLoading` | `boolean` | Yes | Whether a bot response is being streamed. |
+| `onModelClick` | `(id: string, tab?, generationId?) => void` | No | Opens model details. |
+| `hoveredGenerationId` | `string` | No | ID of the message currently highlighted. |
+| `scrollToCompletionId` | `string` | No | When set, scrolls to the matching message. |
+
+## State Variables
+- `copiedMessageId`: `null` – which message was copied to the clipboard.
+
+## useEffect Hooks
+- `[scrollToCompletionId]` – scrolls to a specific message when the ID changes.
+- `[messages, isLoading]` – keeps the list scrolled to the bottom after updates.
+
+## Event Handlers
+- `handleCopyMessage` – triggered by the copy button on each message.
+- `scrollToMessage` – locates a message element and scrolls it into view.
+
+## Data Flow
+- Receives messages and renders them with avatars and timestamps.
+- Calls `onModelClick` when a model or generation ID is clicked.
+
+## Usage Locations
+- `components/chat/ChatInterface.tsx`
+
+## Notes for Juniors
+- Uses `ReactMarkdown` for rich content and memoizes it for performance.

--- a/docs/ModelComparison.md
+++ b/docs/ModelComparison.md
@@ -1,0 +1,31 @@
+# ModelComparison
+
+## Purpose
+- Modal window to compare available models in a table.
+- Lets users search, filter and select a model.
+
+## Props
+| Prop | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| `models` | `ModelInfo[]` | Yes | List of models to show. |
+| `isOpen` | `boolean` | Yes | Whether the modal is visible. |
+| `onClose` | `() => void` | Yes | Closes the modal. |
+| `onSelectModel` | `(id: string) => void` | No | Called when the Select button is clicked. |
+
+## State Variables
+- `searchTerm`: `""` – search input for filtering models.
+
+## useEffect Hooks
+- None
+
+## Event Handlers
+- `handleSelectModel` – invokes `onSelectModel` and closes the modal.
+
+## Data Flow
+- Filters the provided models by name and description before rendering.
+
+## Usage Locations
+- Not imported elsewhere in this repo.
+
+## Notes for Juniors
+- Formatting helpers convert token counts and prices into readable strings.

--- a/docs/ModelDetailsSidebar.md
+++ b/docs/ModelDetailsSidebar.md
@@ -1,0 +1,41 @@
+# ModelDetailsSidebar
+
+## Purpose
+- Sidebar showing detailed information about a selected model.
+- Can display pricing, capabilities and generation metrics.
+
+## Props
+| Prop | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| `model` | `ModelInfo \| null` | Yes | Model to show or `null` for placeholder. |
+| `isOpen` | `boolean` | Yes | Controls sidebar visibility on mobile. |
+| `onClose` | `() => void` | Yes | Closes the sidebar. |
+| `initialTab` | `'overview' \| 'pricing' \| 'capabilities'` | No | Tab shown on open. |
+| `generationId` | `string` | No | Optional generation to fetch pricing for. |
+| `onGenerationHover` | `(id?: string) => void` | No | Highlights a message on hover. |
+| `onGenerationClick` | `(id: string) => void` | No | Scrolls to the related message. |
+
+## State Variables
+- `activeTab`: from `initialTab` – which tab is currently active.
+- `generationData`: `null` – data fetched for `generationId`.
+- `loadingGeneration`: `false` – loading state for generation fetch.
+- `generationError`: `null` – error message from the fetch.
+- `isGenerationIdHovered`: `false` – whether the ID is highlighted.
+
+## useEffect Hooks
+- `[initialTab, model?.id]` – resets the active tab when props change.
+- `[generationId, activeTab]` – fetches generation data when viewing pricing.
+
+## Event Handlers
+- `setActiveTab` triggered by tab buttons.
+- Hover and click handlers on generation IDs communicate with parent callbacks.
+
+## Data Flow
+- Displays `model` information and optionally fetches extra data from `/api/generation`.
+- Uses `Button` for closing and interacts with `MessageList` via hover/click callbacks.
+
+## Usage Locations
+- `components/chat/ChatInterface.tsx`
+
+## Notes for Juniors
+- Clearing `generationData` when the tab changes avoids showing stale info.

--- a/docs/ModelDropdown.md
+++ b/docs/ModelDropdown.md
@@ -1,0 +1,38 @@
+# ModelDropdown
+
+## Purpose
+- Dropdown menu for selecting an AI model.
+- Supports search, filtering and optional enhanced model details.
+
+## Props
+| Prop | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| `models` | `ModelInfo[] \| string[]` | Yes | List of models to choose from. |
+| `selectedModel` | `string` | Yes | Currently chosen model ID. |
+| `onModelSelect` | `(id: string) => void` | Yes | Called when a model is selected. |
+| `isLoading` | `boolean` | No | Disables the dropdown while loading. |
+| `enhanced` | `boolean` | No | Indicates if `models` include extra info. |
+| `onShowDetails` | `(model: ModelInfo) => void` | No | Opens the model details sidebar. |
+
+## State Variables
+- `isOpen`: `false` – whether the listbox is visible.
+- `searchTerm`: `""` – text typed in the search field.
+- `filterBy`: `'all'` – current filter category.
+
+## useEffect Hooks
+- `[isOpen]` – focuses the search input when the menu opens.
+- `[]` – sets up a click-outside listener to close the menu.
+- `[isOpen]` – handles keyboard navigation (Escape/Arrow keys).
+
+## Event Handlers
+- `handleModelSelect` – chooses a model and closes the menu.
+- `handleShowDetails` – calls `onShowDetails` for info buttons.
+
+## Data Flow
+- Filters and formats `models` for display, returning the selected ID via `onModelSelect`.
+
+## Usage Locations
+- `components/chat/ChatInterface.tsx`
+
+## Notes for Juniors
+- Enhanced mode shows badges like "FREE" or "MM" when extra model data is provided.


### PR DESCRIPTION
## Summary
- document MessageList, MessageInput and other chat components
- add docs for all UI components such as ModelDropdown and ModelDetailsSidebar

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68732c325ac083328e46da49edc9e783