### PR TITLE
Add docs for auth store, hooks and components

### DIFF
--- a/docs/components/auth/AuthButton.md
+++ b/docs/components/auth/AuthButton.md
@@ -1,0 +1,31 @@
+# AuthButton
+
+## Purpose
+- Shows a sign in button when the user is logged out.
+- Displays the `UserMenu` when the user is signed in.
+- Opens `SignInModal` to handle Google sign in.
+
+## Props
+| Prop | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| – | – | – | This component does not accept props. |
+
+## State Variables
+- `showSignInModal`: `false` – controls `SignInModal` visibility.
+
+## useEffect Hooks
+- None
+
+## Event Handlers
+- Button click toggles the sign‑in modal.
+- Modal `onClose` hides the modal.
+
+## Data Flow
+- Reads auth state from `AuthContext` via `useAuth`.
+- When authenticated, renders `UserMenu`; otherwise renders a Sign In button.
+
+## Usage Locations
+- Likely used in the site header for authentication actions.
+
+## Notes for Juniors
+- The modal remains open on sign‑in errors so the user can retry.

--- a/docs/components/auth/AuthProvider.md
+++ b/docs/components/auth/AuthProvider.md
@@ -1,0 +1,30 @@
+# AuthProvider
+
+## Purpose
+- Initializes authentication state on app startup.
+- Registers chat synchronization via `useChatSync`.
+- Provides its children once initialization completes.
+
+## Props
+| Prop | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| `children` | `React.ReactNode` | Yes | Elements that require auth context. |
+
+## State Variables
+- `isInitialized` from `useAuthStore` ensures initialization happens once.
+
+## useEffect Hooks
+- Calls `initialize()` when not yet initialized.
+
+## Event Handlers
+- None
+
+## Data Flow
+- Invokes `useChatSync` to keep conversations in sync with the server.
+- Renders `children` directly after setup.
+
+## Usage Locations
+- Wrapped around the root layout in `src/app/layout.tsx`.
+
+## Notes for Juniors
+- Only minimal logic lives here; most auth functions reside in `useAuthStore`.

--- a/docs/components/auth/AuthStatus.md
+++ b/docs/components/auth/AuthStatus.md
@@ -1,0 +1,29 @@
+# AuthStatus
+
+## Purpose
+- Displays the current authentication state using Supabase directly.
+- Shows the signed-in email and a sign out link.
+
+## Props
+| Prop | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| – | – | – | This component does not accept props. |
+
+## State Variables
+- `user`: `null` – the current user from Supabase.
+- `loading`: `true` – indicates initial auth check.
+
+## useEffect Hooks
+- Subscribes to Supabase auth changes on mount.
+
+## Event Handlers
+- Sign out button calls `supabase.auth.signOut()` and redirects home.
+
+## Data Flow
+- Fetches initial session then updates when auth state changes.
+
+## Usage Locations
+- Useful for debugging or lightweight auth status display.
+
+## Notes for Juniors
+- Removing the listener on unmount prevents memory leaks.

--- a/docs/components/auth/SignInModal.md
+++ b/docs/components/auth/SignInModal.md
@@ -1,0 +1,31 @@
+# SignInModal
+
+## Purpose
+- Reusable modal prompting the user to sign in with Google.
+- Provides backdrop click and close button behavior.
+
+## Props
+| Prop | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| `isOpen` | `boolean` | Yes | Whether the modal is visible. |
+| `onClose` | `() => void` | Yes | Called when the user closes the modal. |
+
+## State Variables
+- `loading`: `false` – shows a spinner while signing in.
+
+## useEffect Hooks
+- None
+
+## Event Handlers
+- `handleGoogleSignIn` triggers `signInWithGoogle` from context and handles errors.
+- Clicking the backdrop or close button invokes `onClose`.
+
+## Data Flow
+- Uses `useAuth` for the `signInWithGoogle` method.
+- Renders children only when `isOpen` is true.
+
+## Usage Locations
+- Used by `AuthButton` and potentially other sign-in flows.
+
+## Notes for Juniors
+- Keep the modal mounted only while needed to avoid event listeners persisting.

--- a/docs/components/auth/SimpleAuthButton.md
+++ b/docs/components/auth/SimpleAuthButton.md
@@ -1,0 +1,30 @@
+# SimpleAuthButton
+
+## Purpose
+- Provides a combined sign in / sign out button with a built-in modal.
+- Uses `useAuth` Zustand store for authentication actions.
+
+## Props
+| Prop | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| – | – | – | This component does not accept props. |
+
+## State Variables
+- `showModal`: `false` – toggles the internal modal.
+
+## useEffect Hooks
+- Initializes auth state on mount via `initialize()`.
+
+## Event Handlers
+- `handleSignOut` calls `signOut` from the store.
+- `handleGoogleSignIn` triggers Google authentication and closes the modal.
+
+## Data Flow
+- Shows the user's avatar when authenticated.
+- Displays a modal with a Google sign in button when not authenticated.
+
+## Usage Locations
+- Earlier prototypes before `AuthButton` and `UserMenu` were introduced.
+
+## Notes for Juniors
+- Useful reference for integrating Zustand auth logic with UI components.

--- a/docs/components/auth/UserMenu.md
+++ b/docs/components/auth/UserMenu.md
@@ -1,0 +1,29 @@
+# UserMenu
+
+## Purpose
+- Dropdown menu for authenticated users.
+- Shows profile info and a sign out action.
+
+## Props
+| Prop | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| – | – | – | This component does not accept props. |
+
+## State Variables
+- `isOpen`: `false` – whether the dropdown is visible.
+
+## useEffect Hooks
+- Registers a click listener to close the menu when clicking outside.
+
+## Event Handlers
+- Button click toggles the dropdown.
+- `handleSignOut` calls `signOut` from context and closes the menu.
+
+## Data Flow
+- Reads `user` from `useAuth` to display avatar and name.
+
+## Usage Locations
+- Triggered by `AuthButton` when a user is logged in.
+
+## Notes for Juniors
+- `useRef` is used to detect clicks outside the menu element.

--- a/docs/components/chat/MessageList.md
+++ b/docs/components/chat/MessageList.md
@@ -3,6 +3,7 @@
 ## Purpose
 - Shows the entire conversation thread with copy and scroll helpers.
 - Handles markdown rendering and message highlighting.
+- Displays user avatars for signed in users.
 
 ## Props
 | Prop | Type | Required? | Description |
@@ -15,6 +16,7 @@
 
 ## State Variables
 - `copiedMessageId`: `null` – which message was copied to the clipboard.
+- `failedAvatars`: `Set<string>` – avatar URLs that failed to load.
 
 ## useEffect Hooks
 - `[scrollToCompletionId]` – scrolls to a specific message when the ID changes.
@@ -23,13 +25,17 @@
 ## Event Handlers
 - `handleCopyMessage` – triggered by the copy button on each message.
 - `scrollToMessage` – locates a message element and scrolls it into view.
+- `handleAvatarError` – falls back to initials when the avatar fails to load.
 
 ## Data Flow
 - Receives messages and renders them with avatars and timestamps.
 - Calls `onModelClick` when a model or generation ID is clicked.
+- `useAuthStore` supplies user info for avatar display.
+- Timestamp rendering uses `formatMessageTime` from `lib/utils/dateFormat`.
 
 ## Usage Locations
 - `components/chat/ChatInterface.tsx`
 
 ## Notes for Juniors
 - Uses `ReactMarkdown` for rich content and memoizes it for performance.
+- Avatar images are rendered with Next.js `Image` and fall back to "ME" if they fail to load.

--- a/docs/components/ui/ChatSidebar.md
+++ b/docs/components/ui/ChatSidebar.md
@@ -3,6 +3,7 @@
 ## Purpose
 - Mobile-friendly panel listing previous chat sessions.
 - Allows creating, editing and deleting chat titles.
+- Shows sync status when a user is signed in.
 
 ## Props
 | Prop | Type | Required? | Description |
@@ -13,9 +14,8 @@
 | `className` | `string` | No | Extra CSS classes.
 
 ## State Variables
-- `chatHistory`: sample chats list used for the sidebar.
-- `editingId`: `null` – ID of the chat currently being renamed.
-- `editTitle`: `""` – text for the new title.
+- `editingId`: `null` – ID of the conversation currently being renamed.
+- `editTitle`: `""` – new title value while editing.
 
 ## useEffect Hooks
 - None
@@ -25,12 +25,18 @@
 - `handleSaveEdit` – applies the edited title.
 - `handleCancelEdit` – exits edit mode without saving.
 - `handleDeleteChat` – removes a chat from the list.
+- `manualSync` – manually syncs conversations to the server.
+- `handleClearAllConversations` – deletes all saved conversations.
+- `handleConversationClick` – switches the active conversation and closes the panel on mobile.
 
 ## Data Flow
-- Maintains local chat history and displays it with edit controls.
+- Reads conversations from `useChatStore` and displays them with edit controls.
+- Uses `useChatSync` to sync conversations when authenticated.
+- Relative timestamps are formatted with `formatConversationTimestamp`.
+- When not authenticated, a prompt encourages the user to sign in for sync.
 
 ## Usage Locations
 - `components/chat/ChatInterface.tsx`
 
 ## Notes for Juniors
-- The chat history here is mock data; in a real app you would load it from storage.
+- Conversations come from `useChatStore` and may be synced to the backend when signed in.

--- a/docs/components/ui/Logo.md
+++ b/docs/components/ui/Logo.md
@@ -1,0 +1,31 @@
+# Logo
+
+## Purpose
+- Displays the application logo SVG.
+- `LogoWithText` variant also renders the brand name.
+
+## Props
+| Prop | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| `className` | `string` | No | CSS classes for the `<svg>` wrapper. |
+| `size` | `number` | No | Width and height of the icon in pixels. |
+
+## State Variables
+- None
+
+## useEffect Hooks
+- None
+
+## Event Handlers
+- None
+
+## Data Flow
+- Renders an inline SVG scaled to the provided `size`.
+- `LogoWithText` reads `process.env.BRAND_NAME` for the label.
+
+## Usage Locations
+- `src/app/layout.tsx`
+
+## Notes for Juniors
+- Customize the logo by editing the SVG paths.
+- Remember to provide a fallback brand name if `BRAND_NAME` is undefined.

--- a/docs/hooks/useAuth.md
+++ b/docs/hooks/useAuth.md
@@ -1,0 +1,41 @@
+# useAuth
+
+## Purpose / high-level description
+- Convenience hook that exposes authentication data from `AuthContext`.
+- Also exports `useUser`, `useSession` and `useIsAuthenticated` helpers.
+
+## Parameters
+| Name | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| – | – | – | This hook does not accept parameters. |
+
+## Returned values
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `user` | `User \| null` | Current Supabase user. |
+| `session` | `Session \| null` | Current auth session. |
+| `isAuthenticated` | `boolean` | `true` when `user` is present. |
+| `isLoading` | `boolean` | Indicates if auth actions are in progress. |
+| `isInitialized` | `boolean` | Whether the auth store has initialized. |
+| `error` | `string \| null` | Last auth error message. |
+| `signInWithGoogle` | `() => Promise<void>` | Begins the OAuth sign in flow. |
+| `signOut` | `() => Promise<void>` | Signs out and clears local stores. |
+| `initialize` | `() => Promise<void>` | Loads the current session and subscribes to changes. |
+| `clearError` | `() => void` | Resets the error state. |
+
+## State variables
+- Managed within `useAuthStore`; this hook just exposes them.
+
+## Side effects
+- None
+
+## Persistence mechanisms
+- Underlying store uses `localStorage` via Zustand persistence.
+
+## Example usage
+```tsx
+const { user, signInWithGoogle } = useAuth();
+```
+
+## Notes for juniors
+- Call `initialize` once at app startup via `AuthProvider`.

--- a/docs/hooks/useChatSync.md
+++ b/docs/hooks/useChatSync.md
@@ -1,0 +1,34 @@
+# useChatSync
+
+## Purpose / high-level description
+- Synchronizes local chat history with the server when a user authenticates.
+- Provides periodic auto-sync and a manual sync function.
+
+## Parameters
+| Name | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| – | – | – | This hook takes no parameters. |
+
+## Returned values
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `manualSync` | `() => Promise<void>` | Triggers an immediate sync. |
+| `syncStatus` | `{ isSyncing: boolean; lastSyncTime: Date \| null; syncError: any; canSync: boolean }` | Status information. |
+
+## State variables
+- Derived from `useChatStore` and `useAuthStore`.
+
+## Side effects
+- Runs effects to migrate conversations and auto-sync every 5 minutes.
+- Listens to authentication changes to kick off syncing.
+
+## Persistence mechanisms
+- Relies on chat store persistence for conversation data.
+
+## Example usage
+```tsx
+useChatSync(); // usually inside AuthProvider
+```
+
+## Notes for juniors
+- Ensure `useChatStore` and `useAuthStore` are initialized before calling manual sync.

--- a/docs/hooks/useHydration.md
+++ b/docs/hooks/useHydration.md
@@ -1,0 +1,33 @@
+# useHydration
+
+## Purpose / high-level description
+- Detects when the component has hydrated on the client.
+- Helps avoid SSR and localStorage mismatches.
+
+## Parameters
+| Name | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| – | – | – | This hook accepts no parameters. |
+
+## Returned values
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `isHydrated` | `boolean` | `true` after the first client render. |
+
+## State variables
+- `isHydrated` – `false` initially, toggled true in `useEffect`.
+
+## Side effects
+- Sets the hydrated flag in a `useEffect` once mounted.
+
+## Persistence mechanisms
+- None
+
+## Example usage
+```tsx
+const ready = useHydration();
+if (!ready) return null;
+```
+
+## Notes for juniors
+- Use this when reading from `localStorage` to prevent React hydration warnings.

--- a/docs/hooks/useIsomorphicLayoutEffect.md
+++ b/docs/hooks/useIsomorphicLayoutEffect.md
@@ -1,0 +1,32 @@
+# useIsomorphicLayoutEffect
+
+## Purpose / high-level description
+- Uses `useLayoutEffect` in the browser and `useEffect` during server-side rendering.
+- Prevents React warnings about using layout effect on the server.
+
+## Parameters
+| Name | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| – | – | – | This is a direct export of either hook so no parameters. |
+
+## Returned values
+- The appropriate React effect hook depending on the environment.
+
+## State variables
+- None
+
+## Side effects
+- None
+
+## Persistence mechanisms
+- None
+
+## Example usage
+```tsx
+useIsomorphicLayoutEffect(() => {
+  // Safe to access DOM here
+});
+```
+
+## Notes for juniors
+- Helpful when writing hooks that must run during SSR without warnings.

--- a/docs/stores/useAuthStore.md
+++ b/docs/stores/useAuthStore.md
@@ -1,0 +1,45 @@
+# useAuthStore
+
+## Purpose / Overview
+Manages user authentication state using Zustand and Supabase.
+Provides sign-in, sign-out and initialization helpers used across the app.
+
+## State Shape
+| State Variable | Type | Description |
+| -------------- | ---- | ----------- |
+| `user` | `User \| null` | Current Supabase user. |
+| `session` | `Session \| null` | Active auth session. |
+| `isAuthenticated` | `boolean` | True when a user is logged in. |
+| `isLoading` | `boolean` | Indicates sign-in/out in progress. |
+| `isInitialized` | `boolean` | Whether the store has set up listeners. |
+| `isHydrated` | `boolean` | Set after state rehydrates from storage. |
+| `error` | `string \| null` | Last authentication error. |
+| `lastUpdated` | `Date \| null` | Timestamp of last state change. |
+
+## Actions / Methods
+| Action | Parameters | Description |
+| ------ | ---------- | ----------- |
+| `setUser` | `(user: User \| null)` | Updates user and auth status. |
+| `setSession` | `(session: Session \| null)` | Updates session and user. |
+| `setLoading` | `(loading: boolean)` | Toggles loading flag. |
+| `setInitialized` | `(initialized: boolean)` | Marks initialization complete. |
+| `signInWithGoogle` | `()` | Starts the Google OAuth flow. |
+| `signOut` | `()` | Signs out and clears all other stores. |
+| `initialize` | `()` | Loads current session and subscribes to changes. |
+| `clearAuth` | `()` | Resets auth state to defaults. |
+| `clearAllStores` | `()` | Clears related stores and localStorage keys. |
+| `_hasHydrated` | `()` | Called by Zustand persistence after rehydration. |
+| `clearError` | `()` | Removes any error message. |
+| `reset` | `()` | Restores the initial state. |
+
+## Selectors / Computed State
+- Helper hooks `useAuth`, `useAuthUser` and `useAuthStatus` expose subsets of the store.
+
+## Persistence Behavior
+- Uses Zustand's `persist` middleware to store auth data in `localStorage`.
+
+## SSR Considerations
+- The store should be initialized in `AuthProvider` to avoid hydration mismatches.
+
+## Developer Tips
+- `clearAllStores` dynamically imports other stores to avoid circular dependencies.

--- a/docs/stores/useChatStore.md
+++ b/docs/stores/useChatStore.md
@@ -13,6 +13,9 @@ A hydration flag prevents mismatches during SSR.
 | `isLoading` | `boolean` | `true` while waiting for an API response. |
 | `error` | `ChatError \| null` | Last request error. |
 | `isHydrated` | `boolean` | `true` once state is restored from storage. |
+| `isSyncing` | `boolean` | Indicates a sync request is in progress. |
+| `lastSyncTime` | `Date \| null` | Timestamp of the last successful sync. |
+| `syncError` | `string \| null` | Error message from the last sync attempt. |
 
 ## Actions / Methods
 | Action | Parameters | Description |
@@ -26,6 +29,11 @@ A hydration flag prevents mismatches during SSR.
 | `clearError` | `()` | Reset the `error` state. |
 | `clearMessageError` | `(messageId: string)` | Clear the error flag on a specific message. |
 | `retryLastMessage` | `()` | Resend the last user message. |
+| `syncConversations` | `()` | Upload all user conversations to the server. |
+| `loadUserConversations` | `(userId: string)` | Merge server conversations into local state. |
+| `migrateAnonymousConversations` | `(userId: string)` | Assign existing local conversations to the signed-in user. |
+| `filterConversationsByUser` | `(userId: string \| null)` | Display conversations for the given user. |
+| `clearAllConversations` | `()` | Delete every conversation from local storage. |
 
 ## Selectors / Computed State
 | Selector | Description |
@@ -41,6 +49,7 @@ A hydration flag prevents mismatches during SSR.
 - Uses `persist` with `createJSONStorage` to store conversations in `localStorage`.
 - Only `conversations` and `currentConversationId` are persisted.
 - Dates are deserialized on rehydrate and `_hasHydrated()` sets `isHydrated`.
+- Sync metadata like `lastSyncTime` is kept in memory only.
 
 ## SSR Considerations
 `useChat` and `useChatStore` avoid returning data until `isHydrated` is `true`
@@ -53,3 +62,4 @@ internal state until hydration completes.
 ## Developer Tips
 - `createLogger('ChatStore')` logs actions when devtools are enabled.
 - Store utilities in `storeUtils.ts` provide safe localStorage helpers.
+- Use `syncConversations` after sign-in to ensure local changes reach the server.


### PR DESCRIPTION
## Summary
- document missing auth components under `docs/components/auth`
- document new `Logo` component
- add docs for auth-related hooks and chat synchronization
- add documentation for Zustand `useAuthStore`
- update docs for chat sidebar and message list

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687bc79b70b883329514533c53e768e1