### PR TITLE
Document chat sync endpoint flow

### DIFF
--- a/issues/sync-endpoint.md
+++ b/issues/sync-endpoint.md
@@ -1,0 +1,102 @@
+# /api/chat/sync Endpoint Flow
+
+## Overview
+This document traces the complete path when the `/api/chat/sync` endpoint is called. It covers how the endpoint is triggered in the frontend, the payload sent, what database tables are modified, and which triggers and functions execute downstream.
+
+## When is `/api/chat/sync` Triggered?
+- **After sending a message** – `sendMessage` in `useChatStore` schedules a sync once the assistant reply is stored. The behaviour was implemented in the auto-sync fix.
+- **After editing a conversation title** – `updateConversationTitle` schedules a sync 100 ms after the title update.
+- **During sign‑in** – the `useChatSync` hook performs a sync to upload any locally stored conversations when the user session becomes authenticated.
+
+Relevant excerpt from the auto-sync fix documentation:
+```
+- ✅ After assistant response successfully completes …
+- ✅ When conversation titles are updated manually …
+```
+【F:docs/phase-2-auto-sync-fix.md†L10-L29】
+
+## Payload Sent to the Endpoint
+`syncConversations` collects all conversations that belong to the logged‑in user and POSTs them in a JSON body:
+```ts
+await fetch('/api/chat/sync', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ conversations: userConversations })
+});
+```
+【F:stores/useChatStore.ts†L934-L940】
+
+Each conversation object conforms to `Conversation` in `stores/types/chat.ts` and contains an array of `ChatMessage` items:
+```ts
+export interface Conversation {
+  id: string;
+  title: string;
+  messages: ChatMessage[];
+  userId?: string;
+  createdAt: string;
+  updatedAt: string;
+  messageCount: number;
+  totalTokens: number;
+  …
+}
+```
+【F:stores/types/chat.ts†L5-L18】
+
+`ChatMessage` includes token metadata that is also synced:
+```ts
+export interface ChatMessage {
+  id: string;
+  content: string;
+  role: "user" | "assistant";
+  timestamp: Date;
+  elapsed_time?: number;
+  total_tokens?: number;
+  input_tokens?: number;
+  output_tokens?: number;
+  user_message_id?: string;
+  model?: string;
+  contentType?: "text" | "markdown";
+  completion_id?: string;
+  error?: boolean;
+}
+```
+【F:lib/types/chat.ts†L3-L18】
+
+## Endpoint Logic
+Inside `src/app/api/chat/sync/route.ts`, the POST handler iterates over each conversation and performs upserts:
+1. **Upsert into `chat_sessions`** using the conversation ID and metadata.
+2. **Upsert messages into `chat_messages`** for that session.
+
+If any error occurs per conversation, it is recorded in the `syncResults` object returned to the client.
+【F:src/app/api/chat/sync/route.ts†L60-L128】
+
+## Database Effects
+The direct upserts in the endpoint cause several triggers and functions to run:
+1. **Trigger `on_message_change`** on `chat_messages` fires for every inserted or updated message.
+   - Executes `update_session_stats()` which recalculates message count, tokens and last preview for the session.
+   - Within this function, if the new row is a `user` or `assistant` message, it calls `track_user_usage()` to increment usage statistics.
+【F:database/02-complete-chat-history.sql†L220-L268】
+2. **Trigger `on_session_updated`** on `chat_sessions` runs before each session update and sets `updated_at` and `last_activity`.
+【F:database/02-complete-chat-history.sql†L360-L372】
+3. **`track_user_usage()`** inserts or updates a row in `user_usage_daily` and also updates the `usage_stats` JSON in `profiles`.
+【F:database/03-complete-user-enhancements.sql†L143-L210】
+
+Because the sync endpoint upserts **all** conversations and messages provided by the client, these triggers execute even for rows that have not actually changed. Updating an existing message again passes its token counts into `track_user_usage()`, which increments totals in `user_usage_daily` and `profiles` a second time. This can inflate analytics such as `api_user_summary` and `daily usage` views.
+
+## Suggestions
+- Avoid unnecessary updates by checking whether a message or session already exists and whether any fields changed before upserting.
+- Alternatively, call the database function `sync_user_conversations()` (defined in the schema) which could be extended to handle deduplication within PostgreSQL.
+- Review the trigger logic in `update_session_stats()` so that updates that do not modify token counts do not call `track_user_usage()` again.
+
+## Relevant Scenario Summary
+The steps in *DB_StepThrough.md* describe the same flow:
+```
+1. API endpoint `/api/chat/sync` performs direct upserts …
+2. These upserts trigger `on_message_change` and `on_session_updated` …
+3. Triggers execute `update_session_stats()` and `update_session_timestamp()` …
+4. Backend/API may call `track_user_usage()` to update daily usage stats …
+```
+【F:docs/database/DB_StepThrough.md†L272-L277】
+
+---
+This analysis shows how the sync endpoint currently writes every row, causing all downstream triggers to fire even when data is unchanged. Adjusting the sync strategy or trigger logic would prevent inflated analytics. 


### PR DESCRIPTION
## Summary
- document /api/chat/sync end-to-end flow and database effects

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882e69258d08332a8910ca86fd6f924