### PR TITLE
Add API endpoint documentation

### DIFF
--- a/docs/api/chat-clear-all.md
+++ b/docs/api/chat-clear-all.md
@@ -1,0 +1,11 @@
+# Endpoint: `/api/chat/clear-all`
+
+**Method:** `DELETE`
+
+## Description
+Deletes all chat sessions and their messages for the authenticated user. It fetches the user sessions from Supabase, removes all related messages, then removes the sessions themselves.
+
+## Usage in the Codebase
+- Invoked from `stores/useChatStore.ts` when the user chooses to clear all conversations.
+
+

--- a/docs/api/chat-messages.md
+++ b/docs/api/chat-messages.md
@@ -1,0 +1,11 @@
+# Endpoint: `/api/chat/messages`
+
+**Methods:** `GET`, `POST`
+
+## Description
+Provides CRUD operations for individual chat messages within a session. `GET` fetches all messages for a given session (verifying ownership), while `POST` inserts a new message and updates session statistics.
+
+## Usage in the Codebase
+- Currently not called by the frontend code. Present for potential future use and referenced in documentation.
+
+

--- a/docs/api/chat-sessions.md
+++ b/docs/api/chat-sessions.md
@@ -1,0 +1,11 @@
+# Endpoint: `/api/chat/sessions`
+
+**Methods:** `GET`, `POST`, `DELETE`
+
+## Description
+Manages chat sessions for the authenticated user. `GET` returns all sessions, `POST` creates a new session, and `DELETE` removes a specific session by ID (also deleting its messages).
+
+## Usage in the Codebase
+- Only the `DELETE` method is called from `stores/useChatStore.ts` when a conversation is removed. Other methods are currently unused in the UI.
+
+

--- a/docs/api/chat-sync.md
+++ b/docs/api/chat-sync.md
@@ -1,0 +1,11 @@
+# Endpoint: `/api/chat/sync`
+
+**Methods:** `POST`, `GET`
+
+## Description
+Synchronizes conversations between the client and the server. `POST` accepts an array of conversations from the client and upserts them into Supabase. `GET` returns the latest conversations (with messages) for the authenticated user.
+
+## Usage in the Codebase
+- Called from `stores/useChatStore.ts` to upload local conversations (`POST`) and to load conversations for a user (`GET`).
+
+

--- a/docs/api/chat.md
+++ b/docs/api/chat.md
@@ -1,0 +1,11 @@
+# Endpoint: `/api/chat`
+
+**Method:** `POST`
+
+## Description
+Handles chat completion requests by sending user messages to the OpenRouter API and returning the assistant response with usage and metadata. Performs request validation and token limit calculations before forwarding the request. The endpoint returns the assistant message along with token usage statistics and other metadata.
+
+## Usage in the Codebase
+- Called from `stores/useChatStore.ts` when sending a new message.
+
+

--- a/docs/api/generation-id.md
+++ b/docs/api/generation-id.md
@@ -1,0 +1,11 @@
+# Endpoint: `/api/generation/{id}`
+
+**Method:** `GET`
+
+## Description
+Fetches generation details from the OpenRouter API for the given `id`. It proxies the request to OpenRouter with the configured API key and returns the parsed response.
+
+## Usage in the Codebase
+- Used in `components/ui/ModelDetailsSidebar.tsx` when displaying model pricing or metrics for a completion.
+
+

--- a/docs/api/health-cache.md
+++ b/docs/api/health-cache.md
@@ -1,0 +1,11 @@
+# Endpoint: `/api/health/cache`
+
+**Method:** `GET`
+
+## Description
+Returns the health status of server-side caches, primarily for monitoring model configuration caching. Indicates whether the cache is healthy or degraded.
+
+## Usage in the Codebase
+- Not currently used by the UI. Intended for operations or testing scripts.
+
+

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -1,0 +1,11 @@
+# Endpoint: `/api/models`
+
+**Method:** `GET`
+
+## Description
+Returns the list of available models. When the `enhanced` query parameter is `true`, it fetches and caches model metadata from OpenRouter and filters the response based on allowed models. Otherwise it returns a simple array of model IDs.
+
+## Usage in the Codebase
+- Called from `stores/useModelStore.ts` to populate the model selector (both enhanced and legacy modes).
+
+


### PR DESCRIPTION
## Summary
- add docs/api with endpoint docs for `/api/chat`, `/api/chat/messages`, `/api/chat/sessions`, `/api/chat/sync`, `/api/chat/clear-all`, `/api/generation/{id}`, `/api/models` and `/api/health/cache`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688325e1541c8332a4280ba3f338abd1