### PR TITLE
Improve chat endpoint docs

### DIFF
--- a/docs/api/chat-clear-all.md
+++ b/docs/api/chat-clear-all.md
@@ -2,10 +2,42 @@
 
 **Method:** `DELETE`
 
-## Description
-Deletes all chat sessions and their messages for the authenticated user. It fetches the user sessions from Supabase, removes all related messages, then removes the sessions themselves.
+## Overview
+
+Deletes all chat sessions and their messages for the authenticated user. The endpoint uses Supabase server-side authentication to identify the user, fetches all of their session IDs, removes associated messages from `chat_messages` and then deletes the sessions themselves.
+
+## Authentication & Authorization
+
+- **Authentication Required:** Uses `supabase.auth.getUser()` to ensure the request originates from a signed‑in user.
+- **Authorization:** Each operation is scoped to the authenticated user's `user_id` to prevent cross-account deletion.
+
+## Request
+
+```http
+DELETE /api/chat/clear-all
+```
+
+No body is required; authentication cookies are used implicitly.
+
+## Response
+
+```json
+{
+  "success": true,
+  "message": "All conversations cleared successfully",
+  "deletedCount": 3
+}
+```
+
+If the user has no conversations, `deletedCount` will be `0` and the message will indicate nothing was deleted.
+
+## Data Flow
+
+1. **Lookup Sessions** – Query `chat_sessions` for all IDs belonging to the user.
+2. **Delete Messages** – Remove rows from `chat_messages` where `session_id` matches any of those IDs.
+3. **Delete Sessions** – Remove rows from `chat_sessions` for the user.
+4. **Return Result** – Respond with the number of sessions deleted or an error message if something fails.
 
 ## Usage in the Codebase
+
 - Invoked from `stores/useChatStore.ts` when the user chooses to clear all conversations.
-
-

--- a/docs/api/chat-sync.md
+++ b/docs/api/chat-sync.md
@@ -2,10 +2,78 @@
 
 **Methods:** `POST`, `GET`
 
-## Description
-Synchronizes conversations between the client and the server. `POST` accepts an array of conversations from the client and upserts them into Supabase. `GET` returns the latest conversations (with messages) for the authenticated user.
+## Overview
+
+Synchronizes conversations between the client and the server. `POST` accepts an array of conversations from the client and upserts them into Supabase. `GET` returns the latest conversations (with messages) for the authenticated user. The endpoint enforces conversation ownership, validates feature access and rate limits requests.
+
+## Authentication & Authorization
+
+- **Authentication Required:** Wrapped by `withConversationOwnership`, which in turn uses `withProtectedAuth` to require a signed‑in user.
+- **Feature Check:** Users must have `canSyncConversations` enabled in their feature flags.
+- **Rate Limiting:** All requests pass through `withRateLimit` using the user's tier limits.
+
+## POST Request
+
+```http
+POST /api/chat/sync
+Content-Type: application/json
+
+{
+  "conversations": [
+    {
+      "id": "conv-1",
+      "title": "Example",
+      "messages": [ { "id": "msg-1", "role": "user", "content": "Hello" } ]
+    }
+  ]
+}
+```
+
+## POST Response
+
+```json
+{
+  "success": true,
+  "results": {
+    "synced": 1,
+    "errors": 0,
+    "details": [ { "conversationId": "conv-1", "status": "synced", "messageCount": 1 } ]
+  },
+  "syncTime": "2025-07-29T12:00:00Z"
+}
+```
+
+## GET Request
+
+```http
+GET /api/chat/sync
+```
+
+## GET Response
+
+```json
+{
+  "conversations": [
+    {
+      "id": "conv-1",
+      "title": "Example",
+      "messages": [ { "id": "msg-1", "role": "user", "content": "Hello" } ],
+      "createdAt": "2025-07-29T11:59:00Z",
+      "updatedAt": "2025-07-29T12:00:00Z"
+    }
+  ],
+  "syncTime": "2025-07-29T12:00:00Z"
+}
+```
+
+## Data Flow
+
+1. **Validation** – `withConversationOwnership` parses the payload (for POST) and ensures all conversations belong to the signed‑in user.
+2. **Database Upsert** – Conversations are inserted or updated in the `chat_sessions` table, and each message is upserted into `chat_messages`.
+3. **Stats Update** – Message counts and token totals are updated for each session.
+4. **Fetch Conversations (GET)** – Retrieves up to 20 most recent sessions with their messages sorted by timestamp.
+5. **Rate Limit Headers** – Responses include `X-RateLimit-*` headers added by the middleware.
 
 ## Usage in the Codebase
+
 - Called from `stores/useChatStore.ts` to upload local conversations (`POST`) and to load conversations for a user (`GET`).
-
-

--- a/docs/api/chat.md
+++ b/docs/api/chat.md
@@ -2,10 +2,60 @@
 
 **Method:** `POST`
 
-## Description
-Handles chat completion requests by sending user messages to the OpenRouter API and returning the assistant response with usage and metadata. Performs request validation and token limit calculations before forwarding the request. The endpoint returns the assistant message along with token usage statistics and other metadata.
+## Overview
+
+Handles chat completion requests by sending user messages to the OpenRouter API and returning the assistant response with usage and metadata. The endpoint accepts both the legacy `message` field and the Phase&nbsp;2 `messages` array. It validates the payload against the authenticated user's feature set, applies model‑aware token limits and rate limiting, then forwards the request to OpenRouter. Responses include the assistant message, token usage, elapsed time and other metadata.
+
+## Authentication & Authorization
+
+- **Optional Authentication:** Wrapped by `withEnhancedAuth`, so anonymous requests are allowed.
+- **Rate Limiting:** `withRateLimit` applies per‑tier limits based on `maxRequestsPerHour`.
+- **Feature Checks:** `validateChatRequestWithAuth` ensures optional features (custom system prompt, temperature, etc.) are only used if the user's subscription tier allows them.
+
+## Request
+
+```http
+POST /api/chat
+Content-Type: application/json
+
+{
+  "messages": [
+    { "role": "user", "content": "Hello" }
+  ],
+  "model": "gpt-3.5-turbo",
+  "temperature": 0.7,
+  "systemPrompt": "You are a helpful assistant"
+}
+```
+
+`messages` may be omitted in favor of a single `message` string for legacy clients.
+
+## Response
+
+```json
+{
+  "response": "Hi! How can I assist you today?",
+  "usage": {
+    "prompt_tokens": 12,
+    "completion_tokens": 15,
+    "total_tokens": 27
+  },
+  "request_id": "msg-123",
+  "timestamp": "2025-07-29T12:00:00Z",
+  "elapsed_time": 1.2,
+  "contentType": "markdown",
+  "id": "gen-abc"
+}
+```
+
+## Data Flow
+
+1. **Validation** – `validateChatRequestWithAuth` checks message content, feature access and token counts.
+2. **Token Strategy** – `getModelTokenLimits` determines `max_tokens` for the chosen model; total input tokens are estimated with `estimateTokenCount`.
+3. **OpenRouter Call** – `getOpenRouterCompletion` sends the formatted request to OpenRouter.
+4. **Response Transformation** – `detectMarkdownContent` sets `contentType`; metadata such as `request_id` and `elapsed_time` are added.
+5. **Headers** – Standard rate‑limit headers are included via `addRateLimitHeaders`.
 
 ## Usage in the Codebase
+
 - Called from `stores/useChatStore.ts` when sending a new message.
-
-

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -2,10 +2,67 @@
 
 **Method:** `GET`
 
-## Description
-Returns the list of available models. When the `enhanced` query parameter is `true`, it fetches and caches model metadata from OpenRouter and filters the response based on allowed models. Otherwise it returns a simple array of model IDs.
+## Overview
+
+Provides the client with the list of models that are currently allowed for the user. When the `enhanced` query parameter is `true` (or the `NEXT_PUBLIC_ENABLE_ENHANCED_MODELS` feature flag is enabled) the endpoint contacts the OpenRouter API to fetch detailed model metadata, caches the result and returns the filtered metadata. Without the flag it returns a simple list of model IDs.
+
+## Authentication & Authorization
+
+- **Optional Authentication:** The endpoint is wrapped by `withEnhancedAuth`, meaning requests are allowed without signing in.
+- **Tier Checks:** If the user is authenticated, their `subscription_tier` from Supabase determines which models are returned (`is_free`, `is_pro`, `is_enterprise`). Anonymous users are treated as `free` tier.
+
+## Request
+
+```http
+GET /api/models?enhanced=true
+```
+
+`enhanced` (optional): When `true`, model metadata is fetched from OpenRouter.
+
+## Response
+
+### Enhanced Mode
+
+```json
+{
+  "models": [
+    {
+      "id": "gpt-3.5-turbo",
+      "name": "GPT‑3.5 Turbo",
+      "description": "...",
+      "context_length": 16384,
+      "pricing": { "prompt": "...", "completion": "..." },
+      "input_modalities": ["text"],
+      "output_modalities": ["text"],
+      "supported_parameters": ["max_tokens"]
+    }
+  ]
+}
+```
+
+### Legacy Mode
+
+```json
+{
+  "models": ["gpt-3.5-turbo", "gpt-4", "claude-3-sonnet"]
+}
+```
+
+## Data Flow
+
+1. **Database Query**  
+   Uses the Supabase client to read active rows from the `model_access` table.  
+   Based on the user's tier, only the models with the corresponding flags (`is_free`, `is_pro`, `is_enterprise`) are allowed.
+2. **Enhanced Model Fetch**  
+   If enhanced mode is requested, the service calls `fetchOpenRouterModels()` to retrieve metadata from the OpenRouter API.  
+   The call is wrapped in `unstable_cache` so results are cached for 10 minutes. Subsequent requests within that window reuse the cached response.
+3. **Filtering & Transformation**  
+   The OpenRouter result is filtered against the allowed model IDs and each entry is converted into the simplified `ModelInfo` structure via `transformOpenRouterModel()`.
+4. **Fallback**  
+   Should the OpenRouter request fail, the endpoint falls back to legacy mode and returns only the model IDs.
+5. **Headers**  
+   Monitoring headers such as `X-Enhanced-Mode`, `X-Response-Time`, `X-Cache-Status`, and `X-Fallback-Used` are included for observability.
 
 ## Usage in the Codebase
-- Called from `stores/useModelStore.ts` to populate the model selector (both enhanced and legacy modes).
 
-
+- Invoked from `stores/useModelStore.ts` to populate the model selector.


### PR DESCRIPTION
## Summary
- expand documentation for `/api/chat`, `/api/chat/sync`, and `/api/chat/clear-all`
- include auth requirements, request/response examples, and data flows

## Testing
- No tests run since only documentation was updated

------
https://chatgpt.com/codex/tasks/task_e_688837d9268c8332ad54637ff829efbe