### PR TITLE
Add custom confirm modal for clearing all chats

### DIFF
--- a/components/ui/ChatSidebar.tsx
+++ b/components/ui/ChatSidebar.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { PlusIcon, ChatBubbleLeftIcon, TrashIcon, PencilIcon, EnvelopeIcon, ArrowPathIcon, CloudIcon, ComputerDesktopIcon, Cog6ToothIcon } from "@heroicons/react/24/outline";
 import Button from "./Button";
+import ConfirmModal from "./ConfirmModal";
 import { useChatStore } from "../../stores";
 import { useAuthStore } from "../../stores/useAuthStore";
 import { formatConversationTimestamp } from "../../lib/utils/dateFormat";
@@ -52,6 +53,7 @@ export function ChatSidebar({ isOpen, onClose, onNewChat, className = "" }: Chat
   
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editTitle, setEditTitle] = useState("");
+  const [showConfirmModal, setShowConfirmModal] = useState(false);
 
   // Get recent conversations (limit to 20 for performance)
   // Only show conversations after hydration to prevent SSR mismatch
@@ -94,16 +96,17 @@ export function ChatSidebar({ isOpen, onClose, onNewChat, className = "" }: Chat
 
   const handleClearAllConversations = async () => {
     if (conversations.length === 0) return;
-    
-    const confirmMessage = `Are you sure you want to delete all ${conversations.length} conversations? This action cannot be undone.`;
-    
-    if (window.confirm(confirmMessage)) {
-      try {
-        await clearAllConversations();
-      } catch (error) {
-        console.error('Failed to clear all conversations:', error);
-        alert('Failed to clear conversations. Please try again.');
-      }
+    setShowConfirmModal(true);
+  };
+
+  const confirmClearAll = async () => {
+    try {
+      await clearAllConversations();
+    } catch (error) {
+      console.error('Failed to clear all conversations:', error);
+      alert('Failed to clear conversations. Please try again.');
+    } finally {
+      setShowConfirmModal(false);
     }
   };
 
@@ -376,6 +379,15 @@ export function ChatSidebar({ isOpen, onClose, onNewChat, className = "" }: Chat
           </div>
         </div>
       </aside>
+      <ConfirmModal
+        isOpen={showConfirmModal}
+        onConfirm={confirmClearAll}
+        onCancel={() => setShowConfirmModal(false)}
+        title="Delete all conversations?"
+        description={`Are you sure you want to delete all ${conversations.length} conversations? This action cannot be undone.`}
+        confirmText="Delete"
+        cancelText="Cancel"
+      />
     </>
   );
 }

--- a/components/ui/ConfirmModal.tsx
+++ b/components/ui/ConfirmModal.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { XMarkIcon } from '@heroicons/react/24/outline'
+import Button from './Button'
+import { ReactNode } from 'react'
+
+interface ConfirmModalProps {
+  isOpen: boolean
+  title: string
+  description?: string
+  confirmText?: string
+  cancelText?: string
+  onConfirm: () => void
+  onCancel: () => void
+  children?: ReactNode
+}
+
+export default function ConfirmModal({
+  isOpen,
+  title,
+  description,
+  confirmText = 'Confirm',
+  cancelText = 'Cancel',
+  onConfirm,
+  onCancel,
+  children
+}: Readonly<ConfirmModalProps>) {
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="fixed inset-0 bg-black/50" onClick={onCancel} />
+      <div className="relative bg-white dark:bg-gray-800 text-black dark:text-white rounded-lg shadow-xl w-full max-w-sm mx-auto p-6">
+        <button
+          onClick={onCancel}
+          className="absolute top-4 right-4 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+        >
+          <XMarkIcon className="h-5 w-5" />
+        </button>
+        <h2 className="text-lg font-semibold mb-2 text-center">{title}</h2>
+        {description && (
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-4 text-center">
+            {description}
+          </p>
+        )}
+        {children}
+        <div className="mt-6 flex justify-end gap-2">
+          <Button variant="secondary" size="sm" onClick={onCancel}>
+            {cancelText}
+          </Button>
+          <Button variant="primary" size="sm" onClick={onConfirm}>
+            {confirmText}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- implement new `ConfirmModal` component for generic confirmations
- use `ConfirmModal` when clearing all conversations in `ChatSidebar`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a5365f574833283ded50766c9387b