### PR TITLE
feat: add user settings modal

### DIFF
--- a/components/ui/ChatSidebar.tsx
+++ b/components/ui/ChatSidebar.tsx
@@ -4,10 +4,10 @@ import { useState } from "react";
 import { PlusIcon, ChatBubbleLeftIcon, TrashIcon, PencilIcon, EnvelopeIcon, ArrowPathIcon, CloudIcon, ComputerDesktopIcon, Cog6ToothIcon } from "@heroicons/react/24/outline";
 import Button from "./Button";
 import ConfirmModal from "./ConfirmModal";
+import UserSettings from "./UserSettings";
 import { useChatStore } from "../../stores";
 import { useAuthStore } from "../../stores/useAuthStore";
 import { formatConversationTimestamp } from "../../lib/utils/dateFormat";
-import toast from "react-hot-toast";
 
 interface ChatSidebarProps {
   isOpen: boolean;
@@ -55,7 +55,7 @@ export function ChatSidebar({ isOpen, onClose, onNewChat, className = "" }: Chat
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editTitle, setEditTitle] = useState("");
   const [showConfirmModal, setShowConfirmModal] = useState(false);
-  const [isSettingsSpinning, setIsSettingsSpinning] = useState(false);
+  const [showSettingsModal, setShowSettingsModal] = useState(false);
 
   // Get recent conversations (limit to 20 for performance)
   // Only show conversations after hydration to prevent SSR mismatch
@@ -125,20 +125,7 @@ export function ChatSidebar({ isOpen, onClose, onNewChat, className = "" }: Chat
   };
 
   const handleSettingsClick = () => {
-    const user = useAuthStore.getState().user;
-    const userInfo = user?.id || user?.email || "unknown";
-    console.log(`Clicked settings button for user ${userInfo}`);
-    toast.success("Settings button clicked! Toast is working!", {
-      id: 'settings-debug',
-    });
-    
-    // Start spinning animation
-    setIsSettingsSpinning(true);
-    
-    // Stop spinning after 1 second
-    setTimeout(() => {
-      setIsSettingsSpinning(false);
-    }, 1000);
+    setShowSettingsModal(true);
   };
 
   return (
@@ -383,7 +370,7 @@ export function ChatSidebar({ isOpen, onClose, onNewChat, className = "" }: Chat
                   className="p-1 text-gray-400 hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors rounded"
                   title="Settings"
                 >
-                  <Cog6ToothIcon className={`w-4 h-4 ${isSettingsSpinning ? 'animate-spin' : ''}`} />
+                  <Cog6ToothIcon className="w-4 h-4" />
                 </button>
               )}
               {isHydrated && conversations.length > 0 && (
@@ -399,6 +386,10 @@ export function ChatSidebar({ isOpen, onClose, onNewChat, className = "" }: Chat
           </div>
         </div>
       </aside>
+      <UserSettings
+        isOpen={showSettingsModal}
+        onClose={() => setShowSettingsModal(false)}
+      />
       <ConfirmModal
         isOpen={showConfirmModal}
         onConfirm={confirmClearAll}

--- a/components/ui/UserSettings.tsx
+++ b/components/ui/UserSettings.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import Button from "./Button";
+
+interface UserSettingsProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function UserSettings({ isOpen, onClose }: Readonly<UserSettingsProps>) {
+  if (!isOpen) return null;
+
+  const user = {
+    email: "user@example.com",
+    fullName: "Jane Doe",
+    subscription: "Free",
+  };
+
+  const preferences = {
+    theme: "Light",
+    defaultModel: "gpt-3.5",
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="fixed inset-0 bg-black/50" onClick={onClose} />
+      <div className="relative bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 rounded-lg shadow-xl w-full max-w-lg p-6 overflow-y-auto max-h-[90vh]">
+        <h2 className="text-xl font-semibold mb-4">User Settings</h2>
+
+        <section className="mb-6">
+          <h3 className="text-lg font-medium mb-2">Profile</h3>
+          <p className="text-sm">Email: {user.email}</p>
+          <p className="text-sm">Name: {user.fullName}</p>
+          <p className="text-sm">Subscription: {user.subscription}</p>
+        </section>
+
+        <section className="mb-6">
+          <h3 className="text-lg font-medium mb-2">Preferences</h3>
+          <p className="text-sm">Theme: {preferences.theme}</p>
+          <p className="text-sm">Default Model: {preferences.defaultModel}</p>
+        </section>
+
+        <section>
+          <h3 className="text-lg font-medium mb-2">Analytics</h3>
+          <p className="text-sm">Messages sent today: 42</p>
+          <p className="text-sm">Tokens used today: 12345</p>
+        </section>
+
+        <div className="mt-6 flex justify-end">
+          <Button variant="primary" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/components/ui/ChatSidebar.md
+++ b/docs/components/ui/ChatSidebar.md
@@ -4,6 +4,7 @@
 - Mobile-friendly panel listing previous chat sessions.
 - Allows creating, editing and deleting chat titles.
 - Shows sync status when a user is signed in.
+- Provides access to user settings.
 
 ## Props
 | Prop | Type | Required? | Description |
@@ -28,6 +29,7 @@
 - `manualSync` – manually syncs conversations to the server.
 - `handleClearAllConversations` – deletes all saved conversations.
 - `handleConversationClick` – switches the active conversation and closes the panel on mobile.
+- `handleSettingsClick` – opens the `UserSettings` modal.
 
 ## Data Flow
 - Reads conversations from `useChatStore` and displays them with edit controls.

--- a/docs/components/ui/UserSettings.md
+++ b/docs/components/ui/UserSettings.md
@@ -1,0 +1,25 @@
+# UserSettings
+
+## Purpose
+- Modal panel displaying user profile, preferences, and usage metrics.
+- Currently uses placeholder data with no backend connections.
+
+## Props
+| Prop | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| `isOpen` | `boolean` | Yes | Whether the modal is visible. |
+| `onClose` | `() => void` | Yes | Callback invoked to close the modal. |
+
+## Sections
+- **Profile:** Shows email, display name, and subscription tier.
+- **Preferences:** Shows theme and default model selections.
+- **Analytics:** Displays dummy usage numbers for messages and tokens.
+
+## Event Handlers
+- `onClose` — closes the modal when background or Close button is clicked.
+
+## Usage Locations
+- Triggered from `ChatSidebar` via the settings icon.
+
+## Notes for Juniors
+- Replace placeholder data with real values from stores or API when backend is ready.

--- a/specs/user-settings-design.md
+++ b/specs/user-settings-design.md
@@ -1,0 +1,74 @@
+# User Settings and Analytics Design
+
+## Overview
+
+This document explores the database structures related to user details, preferences, and analytics. It outlines what data can surface in a settings experience, highlights configurable options, and proposes a user interface design that respects subscription tiers.
+
+## Relevant Database Entities
+
+### `public.profiles`
+Holds core user information, preferences, and usage counters:
+- Basic info: `email`, `full_name`, `avatar_url`
+- Model defaults: `default_model`, `temperature`, `system_prompt`
+- Subscription and credits: `subscription_tier`, `credits`
+- Usage counters: `usage_stats`
+- Preferences: `ui_preferences`, `session_preferences`
+
+### `public.user_activity_log`
+Audit trail of user actions with `action`, `resource_type`, `details`, `timestamp`, and client metadata (`ip_address`, `user_agent`).
+
+### `public.user_usage_daily`
+Per‑day usage metrics (`messages_sent`, `input_tokens`, `models_used`, `sessions_created`, `active_minutes`, `estimated_cost`).
+
+### `public.chat_sessions` and `public.chat_messages`
+Conversation metadata (`message_count`, `total_tokens`, `last_model`) and per‑message stats (`role`, `model`, `input_tokens`, `output_tokens`, `error_message`, `metadata`).
+
+### `public.model_access`
+Catalog of available models with tier flags (`is_free`, `is_pro`, `is_enterprise`) and rate limits (`daily_limit`, `monthly_limit`).
+
+### `public.system_stats`
+Aggregated platform statistics for admins (`total_users`, `total_conversations`, `total_tokens`, performance and storage metrics).
+
+## Functions of Interest
+- `log_user_activity(p_user_id, p_action, …)` – records events in the activity log.
+- `track_user_usage(p_user_id, p_messages_sent, …)` – updates daily usage and profile counters.
+- `update_user_tier(user_uuid, new_tier)` – changes subscription tier.
+- `get_user_allowed_models(user_uuid)` / `can_user_use_model(user_uuid, model_to_check)` – resolve model access by tier.
+- `export_user_data(user_uuid)` – bundles profile, conversations, activity, and usage for download.
+
+## What to Display or Configure
+
+### Profile Section
+Display `email`, `full_name`, `avatar_url`, `subscription_tier`, and `credits`. Allow editing of `full_name` and `avatar_url`. Include upgrade link if tier < desired feature.
+
+### Model Preferences
+Expose `default_model`, `temperature`, and `system_prompt`. Limit `default_model` choices to results from `get_user_allowed_models`. For lower tiers, disable advanced models and show an upgrade prompt.
+
+### UI Preferences
+Toggle fields from `ui_preferences` such as theme, sidebar width, token count display, code highlighting, and compact mode.
+
+### Session Preferences
+Options from `session_preferences` (max history, auto title, auto‑save interval, timestamp display, export format). Some power features—e.g., higher history limits or advanced export formats—can be gated to Pro/Enterprise.
+
+### Usage & Analytics
+Provide totals from `usage_stats` and recent daily metrics (`messages_sent`, `tokens`, `active_minutes`). Offer charts or tables summarizing `user_usage_daily` records. Admins may view system‑wide `system_stats`.
+
+### Activity Log
+Show recent `user_activity_log` entries. For personal accounts this can be a collapsible list; admins may filter or search.
+
+## UI Presentation
+
+- **Access Point**: The current settings icon in `ChatSidebar`’s footer can open a slide‑up panel anchored to the bottom to keep context, or trigger a centered modal for a focused experience.
+- **Layout**: Organize settings into tabs or accordion sections: Profile, Preferences, Analytics, Subscription.
+- **Tier Awareness**: Grey out or badge features that require higher tiers and provide inline upgrade CTAs. When an action is attempted on a restricted feature, show an upgrade modal.
+- **Responsiveness**: On mobile, use a full‑screen drawer. On desktop, a right‑side slide‑over could preserve chat visibility while adjusting settings.
+
+## Subscription‑Tier Considerations
+
+- **Model Access**: Only list models flagged for the user’s tier; indicate locked models with an upgrade hint.
+- **Limits**: Display remaining credits and daily/monthly limits where applicable.
+- **Advanced Features**: Options such as increased `max_history`, detailed usage analytics, or activity log export could be enabled only for Pro/Enterprise tiers.
+
+## Summary
+The schema supports a rich settings experience centered on the `profiles` table and augmented by activity, usage, and model‑access data. A tier‑aware, modular UI can surface these capabilities while incentivizing upgrades.
+

--- a/tests/components/ui/UserSettings.test.tsx
+++ b/tests/components/ui/UserSettings.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import UserSettings from '../../../components/ui/UserSettings';
+
+describe('UserSettings', () => {
+  it('renders when open', () => {
+    render(<UserSettings isOpen={true} onClose={() => {}} />);
+    expect(screen.getByText('User Settings')).toBeInTheDocument();
+    expect(screen.getByText(/Email:/)).toBeInTheDocument();
+  });
+
+  it('does not render when closed', () => {
+    const { container } = render(<UserSettings isOpen={false} onClose={() => {}} />);
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add UserSettings modal component with placeholder profile, preference, and analytics sections
- wire ChatSidebar settings icon to open the UserSettings modal and update documentation
- cover modal with basic unit test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892b256ab708332b8e075f16bddb0a2