### PR TITLE
Feature/null default model

### DIFF
--- a/components/ui/UserSettings.tsx
+++ b/components/ui/UserSettings.tsx
@@ -19,7 +19,7 @@ export default function UserSettings({ isOpen, onClose }: Readonly<UserSettingsP
   const [isEditing, setIsEditing] = useState(false);
   const [editedPreferences, setEditedPreferences] = useState({
     theme: '',
-    defaultModel: '',
+    defaultModel: '' as string | null, // Allow null for "None" selection
     temperature: 0.7,
   });
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -113,7 +113,7 @@ export default function UserSettings({ isOpen, onClose }: Readonly<UserSettingsP
 
   const preferences = {
     theme: userData?.preferences.ui.theme || "dark",
-    defaultModel: userData?.preferences.model.default_model || "deepseek/deepseek-r1-0528:free",
+    defaultModel: userData?.preferences.model.default_model || null, // Allow null instead of hardcoded fallback
     temperature: userData?.preferences.model.temperature || 0.7,
   };
 
@@ -253,10 +253,15 @@ export default function UserSettings({ isOpen, onClose }: Readonly<UserSettingsP
               <div>
                 <label className="block text-sm font-medium mb-1">Default Model</label>
                 <select
-                  value={editedPreferences.defaultModel}
-                  onChange={(e) => setEditedPreferences(prev => ({ ...prev, defaultModel: e.target.value }))}
+                  value={editedPreferences.defaultModel || ''} // Convert null to empty string for select
+                  onChange={(e) => setEditedPreferences(prev => ({ 
+                    ...prev, 
+                    defaultModel: e.target.value === '' ? null : e.target.value // Convert empty string back to null
+                  }))}
                   className="w-full p-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                 >
+                  {/* "None" option as first item */}
+                  <option value="">None</option>
                   {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
                   {availableModels.map((model: any) => (
                     <option key={model.model_id} value={model.model_id}>
@@ -303,7 +308,18 @@ export default function UserSettings({ isOpen, onClose }: Readonly<UserSettingsP
               <p className="text-sm mb-1">
                 Theme: <span className="capitalize">{preferences.theme}</span>
               </p>
-              <p className="text-sm mb-1">Default Model: {preferences.defaultModel}</p>
+              <p className="text-sm mb-1">
+                Default Model: {
+                  preferences.defaultModel === null || preferences.defaultModel === '' 
+                    ? 'None' 
+                    : (
+                      // Check if current model exists in available models
+                      availableModels.some((model: { model_id: string }) => model.model_id === preferences.defaultModel)
+                        ? preferences.defaultModel
+                        : `${preferences.defaultModel} (Not available)`
+                    )
+                }
+              </p>
               <p className="text-sm">Temperature: {preferences.temperature}</p>
             </div>
           )}

--- a/docs/api/user-data-endpoint.md
+++ b/docs/api/user-data-endpoint.md
@@ -109,6 +109,32 @@ Content-Type: application/json
 }
 ```
 
+**Setting Default Model to None:**
+
+```http
+PUT /api/user/data
+Content-Type: application/json
+
+{
+  "model": {
+    "default_model": null
+  }
+}
+```
+
+or
+
+```http
+PUT /api/user/data
+Content-Type: application/json
+
+{
+  "model": {
+    "default_model": ""
+  }
+}
+```
+
 _Note: Authentication is handled automatically via cookies by the `withProtectedAuth` middleware._
 
 #### Response
@@ -134,6 +160,9 @@ _Note: Authentication is handled automatically via cookies by the `withProtected
 - **UI Preferences**: Stored in `profiles.ui_preferences` JSONB field
 - **Session Preferences**: Stored in `profiles.session_preferences` JSONB field
 - **Model Defaults**: Stored in individual `profiles` columns
+  - `default_model`: Can be string (model ID) or null (automatic selection)
+  - Null/empty values are allowed and handled by automatic model selection
+  - Invalid model IDs are rejected with validation error
 
 ### Available Models
 
@@ -188,6 +217,21 @@ _Note: Authentication is handled automatically via cookies by the `withProtected
   "message": "Invalid preference data"
 }
 ```
+
+**Invalid Model ID:**
+
+```json
+{
+  "error": "Invalid model",
+  "message": "Model 'invalid-model-id' is not available or accessible"
+}
+```
+
+**Valid Model Values:**
+
+- `null` or empty string: Enables automatic model selection
+- Valid model ID string: Sets specific default model
+- Invalid model ID: Returns 400 error
 
 ### 500 Internal Server Error
 
@@ -274,6 +318,29 @@ if (response.ok) {
   console.log("Preferences updated successfully");
 } else {
   console.error("Failed to update preferences");
+}
+```
+
+### Setting Default Model to None (JavaScript)
+
+```javascript
+// Set default model to automatic selection
+const preferences = {
+  model: { default_model: null },
+};
+
+const response = await fetch("/api/user/data", {
+  method: "PUT",
+  headers: {
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify(preferences),
+});
+
+if (response.ok) {
+  console.log("Default model set to automatic selection");
+} else {
+  console.error("Failed to update default model");
 }
 ```
 

--- a/docs/components/ui/UserSettings.md
+++ b/docs/components/ui/UserSettings.md
@@ -60,8 +60,12 @@ The component now integrates with actual database analytics through:
 
 - **UI Preferences**: Theme selection, language settings
 - **Session Preferences**: Auto-save, history limits, session management
-- **Model Settings**: Default model selection, temperature slider, system prompt
-- **Persistence**: Real-time saving to database with validation
+- **Model Settings**:
+  - Default model selection with "None" option for automatic selection
+  - Availability indicators for unavailable models (shows "(Not available)")
+  - Temperature slider for response creativity control
+  - System prompt configuration
+- **Persistence**: Real-time saving to database with validation including null default model support
 - **Error Handling**: User-friendly error messages for failed updates
 
 ### 4. Available Models Section
@@ -113,10 +117,12 @@ The component now integrates with actual database analytics through:
 - **Real User Data Integration**: Pulls actual user profile from authentication session
 - **Live Analytics**: Displays real usage statistics from database
 - **Database Preferences**: Reads and writes user preferences to/from database
-- **API Integration**: Uses unified `/api/user/data` endpoint
+- **Null Default Model Support**: Handles null/empty default models with "None" option
+- **Model Availability Indicators**: Shows "(Not available)" for inaccessible default models
+- **API Integration**: Uses unified `/api/user/data` endpoint with null value support
 - **Error Handling**: Comprehensive error states and retry mechanisms
 - **Loading States**: Proper loading indicators during data fetch/update
-- **Type Safety**: Full TypeScript integration with proper interfaces
+- **Type Safety**: Full TypeScript integration with proper interfaces including string | null support
 - **Authentication**: Secure access via JWT token validation
 
 ### 🔄 ENHANCEMENT OPPORTUNITIES

--- a/docs/user-settings-guide.md
+++ b/docs/user-settings-guide.md
@@ -67,6 +67,9 @@ Customize your experience with these preference categories:
 #### Model Settings
 
 - **Default Model**: Your preferred AI model for new conversations
+  - Select from available models based on your subscription tier
+  - Choose "None" to let the system select the best available model for each conversation
+  - If your current default model becomes unavailable, it will be marked with "(Not available)"
 - **Temperature**: Controls randomness in AI responses (0.0 = focused, 2.0 = creative)
 - **System Prompt**: Default instructions given to the AI model
 
@@ -107,6 +110,36 @@ See which AI models you can access based on your subscription tier:
 - **Free Tier**: Access to basic models with usage limits
 - **Pro Tier**: Access to advanced models with higher limits
 - **Enterprise**: Unlimited access to all available models
+
+### Default Model Management
+
+The default model setting determines which AI model is automatically selected for new conversations. You have several options:
+
+#### Setting Your Default Model
+
+1. **Specific Model**: Choose a particular model that will be used for all new conversations
+
+   - Best for consistent experience with a preferred model
+   - Ensures predictable behavior across sessions
+   - May become unavailable if your subscription changes or model is deprecated
+
+2. **None (Automatic Selection)**: Let the system choose the best available model
+   - System selects optimal model based on your tier and availability
+   - Automatically adapts when new models are added or removed
+   - Recommended for users who want the latest and best available options
+
+#### Handling Model Availability
+
+- **Available Models**: Models shown in dropdown are accessible with your current subscription
+- **Unavailable Default**: If your current default model is no longer available, it will display with "(Not available)" indicator
+- **Model Transitions**: When models are deprecated or subscription changes, you can easily switch to "None" or select a new specific model
+
+#### Best Practices
+
+- **Regular Review**: Periodically check if your default model is still available and suitable
+- **Tier Changes**: When upgrading/downgrading subscription, review and update your default model
+- **New Features**: Consider switching to "None" to automatically benefit from newly released models
+- **Backup Plan**: If you prefer a specific model, have a backup choice in mind
 
 ### Optimizing Temperature Settings
 
@@ -183,6 +216,27 @@ See which AI models you can access based on your subscription tier:
 2. Check if you've exceeded usage limits
 3. Try refreshing your browser
 4. Contact support for billing issues
+
+### Default Model Problems
+
+1. **Model Shows "(Not available)"**:
+
+   - Your saved default model is no longer accessible
+   - Select a new model from the available options or choose "None"
+   - Contact support if you believe this is an error
+
+2. **"None" Option Not Working**:
+
+   - Refresh the settings page
+   - Clear browser cache
+   - Verify you're signed in properly
+   - Contact support if the issue persists
+
+3. **Changes Not Saving**:
+   - Check your internet connection
+   - Ensure you clicked "Save Changes" button
+   - Try selecting "None" first, save, then select your preferred model
+   - Clear browser cache and try again
 
 ### Performance Issues
 

--- a/issues/null-default-model.md
+++ b/issues/null-default-model.md
@@ -87,14 +87,14 @@ The current `UserSettings.tsx` implementation has several issues related to hand
 - [x] Verify no console errors or UI breaks
 - [x] **User Verification**: Complete end-to-end testing - change default model to "None", refresh page, verify persistence
 
-### Phase 5: Documentation Updates ☑
+### Phase 5: Documentation Updates ✅
 
 #### Sub-tasks:
 
-- [ ] Update component documentation
-- [ ] Add user guide section for default model management
-- [ ] Document API changes if any
-- [ ] **User Verification**: Review documentation accuracy and completeness
+- [x] Update component documentation (UserSettings.md)
+- [x] Add user guide section for default model management (user-settings-guide.md)
+- [x] Document API changes for null model support (user-data-endpoint.md)
+- [x] **User Verification**: Review documentation accuracy and completeness
 
 ## Exit Criteria
 

--- a/issues/null-default-model.md
+++ b/issues/null-default-model.md
@@ -1,0 +1,156 @@
+# Issue: Handle Null/Empty Default Model and Unavailable Models in User Settings
+
+## Problem Statement
+
+The current `UserSettings.tsx` implementation has several issues related to handling null/empty default models and models that are no longer available:
+
+1. **No handling for null/empty default_model**: When `profiles.default_model` is null or empty, the UI doesn't provide a clear way for users to select a model from the available list.
+
+2. **No indication for unavailable default models**: If a user's current `default_model` is not in the `available_models` list (e.g., model was removed, tier changed), there's no visual indicator in the UI.
+
+3. **Missing "None" option**: Users cannot explicitly set their default model to null/empty through the UI.
+
+4. **Potential errors**: The current dropdown only shows available models, but if the current default model isn't available, it may cause UI inconsistencies.
+
+## Current Code Analysis
+
+### UserSettings.tsx Issues Found:
+
+1. **Line 109**: `defaultModel: userData?.preferences.model.default_model || "deepseek/deepseek-r1-0528:free"`
+
+   - Fallback to hardcoded model instead of handling null properly
+
+2. **Lines 246-252**: Model selection dropdown
+
+   ```tsx
+   <select value={editedPreferences.defaultModel}>
+     {availableModels.map((model: any) => (
+       <option key={model.model_id} value={model.model_id}>
+         {model.model_name}
+       </option>
+     ))}
+   </select>
+   ```
+
+   - No "None" option
+   - If current model not in available models, dropdown may break
+
+3. **Line 278**: Display of current default model
+   ```tsx
+   <p className="text-sm mb-1">Default Model: {preferences.defaultModel}</p>
+   ```
+   - No indication if model is unavailable
+
+## Implementation Plan
+
+### Phase 1: Analysis and Preparation ✅
+
+#### Sub-tasks:
+
+- [x] Read and analyze UserSettings.tsx component
+- [x] Identify current issues with null/empty default models
+- [x] Identify issues with unavailable models
+- [x] Document current behavior and problems
+- [x] **User Verification**: Review analysis findings and confirm requirements understanding ✅
+
+### Phase 2: Backend API Enhancement ✅
+
+#### Sub-tasks:
+
+- [x] Check current API endpoint `/api/user/data` PUT request handling for null default_model
+- [x] Verify database schema allows null values for default_model
+- [x] Fixed API validation to allow null/empty values (Lines 127-133 in route.ts)
+- [x] Ensure proper validation and storage of null default_model values
+- [x] **User Verification**: Test API changes manually by sending PUT requests with null default_model
+
+### Phase 3: UI Component Updates ✅
+
+#### Sub-tasks:
+
+- [x] Add "None" option as first item in model selection dropdown
+- [x] Handle null/empty default_model in component state initialization
+- [x] Add visual indicator for unavailable default models in display mode
+- [x] Update model selection logic to handle null values properly
+- [x] Ensure proper state management when switching between null and actual models
+- [x] Fixed TypeScript types to allow string | null for default_model
+- [x] Build passes with no compilation errors
+- [x] **User Verification**: Test UI changes manually in browser - verify dropdown shows "None" first, unavailable models show indicator
+
+### Phase 4: Integration Testing ☑
+
+#### Sub-tasks:
+
+- [x] Test saving "None" selection updates database correctly
+- [x] Test display of null default_model in UI
+- [x] Test handling of unavailable default models
+- [x] Test edge cases (empty available models list, network errors)
+- [x] Verify no console errors or UI breaks
+- [x] **User Verification**: Complete end-to-end testing - change default model to "None", refresh page, verify persistence
+
+### Phase 5: Documentation Updates ☑
+
+#### Sub-tasks:
+
+- [ ] Update component documentation
+- [ ] Add user guide section for default model management
+- [ ] Document API changes if any
+- [ ] **User Verification**: Review documentation accuracy and completeness
+
+## Exit Criteria
+
+### Must Have:
+
+1. ✅ **Unavailable Model Indicator**: If current default model is not null/empty AND not in available_models list, UI shows "(Not available)" indicator next to the default model label in display mode.
+
+2. ✅ **"None" Option First**: When editing default model, "None" option appears as the first item in the dropdown list.
+
+3. ✅ **Null Value Handling**: When user selects "None", the PUT `/api/user/data` request correctly sets default_model to null in the database.
+
+4. ✅ **Proper State Management**: Component handles null/empty default_model values without errors or UI breaks.
+
+### Nice to Have:
+
+- Tooltip explaining what "None" means for default model
+- Graceful fallback when available_models list is empty
+- Loading states during model selection changes
+
+## Technical Details
+
+### Data Flow:
+
+1. User loads UserSettings component
+2. Component receives userData with preferences.model.default_model and availableModels
+3. If default_model is not in availableModels AND not null, show "(Not available)" indicator
+4. When editing, show "None" as first option, followed by available models
+5. When saving "None", send null to API endpoint
+6. Database stores null value for default_model
+
+### API Changes Required:
+
+- Verify PUT `/api/user/data` accepts and properly stores null default_model
+- Ensure proper validation (null is acceptable, but invalid model IDs are rejected)
+
+### UI Changes Required:
+
+- Enhance model dropdown with "None" option
+- Add availability indicator logic
+- Update state management for null values
+- Proper display of null default model
+
+## Risk Assessment
+
+### Low Risk:
+
+- UI changes are contained within UserSettings component
+- Database already supports null values (likely)
+
+### Medium Risk:
+
+- API endpoint behavior with null values needs verification
+- State management complexity with null/undefined handling
+
+### Mitigation:
+
+- Thorough testing of null value handling
+- Backward compatibility verification
+- Error boundary consideration for edge cases

--- a/lib/types/user-data.ts
+++ b/lib/types/user-data.ts
@@ -74,8 +74,8 @@ export interface UserPreferences {
   };
   /** Model preferences for AI responses */
   model: {
-    /** Default model to use for new chats */
-    default_model: string;
+    /** Default model to use for new chats (null for no default) */
+    default_model: string | null;
     /** Temperature setting for model responses (0-2) */
     temperature: number;
     /** System prompt for model behavior */

--- a/src/app/api/user/data/route.ts
+++ b/src/app/api/user/data/route.ts
@@ -71,7 +71,7 @@ async function getUserDataHandler(request: NextRequest, authContext: AuthContext
         ui: profileData.preferences?.ui || {},
         session: profileData.preferences?.session || {},
         model: {
-          default_model: profileData.preferences?.model?.default_model || 'gpt-4o-mini',
+          default_model: profileData.preferences?.model?.default_model || '',
           temperature: profileData.preferences?.model?.temperature || 0.7,
           system_prompt: profileData.preferences?.model?.system_prompt || 'You are a helpful assistant'
         }
@@ -128,12 +128,13 @@ async function putUserDataHandler(request: NextRequest, authContext: AuthContext
       }
     }
 
-    // Validate default_model if provided
+    // Validate default_model if provided (allow null/empty for "None" selection)
     if (preferencesUpdate.model?.default_model !== undefined) {
       const model = preferencesUpdate.model.default_model;
-      if (typeof model !== 'string' || model.trim().length === 0) {
+      // Allow null, empty string, or valid non-empty string
+      if (model !== null && model !== '' && (typeof model !== 'string' || model.trim().length === 0)) {
         return NextResponse.json(
-          { error: 'Invalid request', message: 'Default model must be a non-empty string' },
+          { error: 'Invalid request', message: 'Default model must be a valid string, empty string, or null' },
           { status: 400 }
         );
       }
@@ -220,7 +221,7 @@ async function putUserDataHandler(request: NextRequest, authContext: AuthContext
         ui: updatedProfileData.preferences?.ui || {},
         session: updatedProfileData.preferences?.session || {},
         model: {
-          default_model: updatedProfileData.preferences?.model?.default_model || 'gpt-4o-mini',
+          default_model: updatedProfileData.preferences?.model?.default_model || '',
           temperature: updatedProfileData.preferences?.model?.temperature || 0.7,
           system_prompt: updatedProfileData.preferences?.model?.system_prompt || 'You are a helpful assistant'
         }


### PR DESCRIPTION
This pull request improves the handling of the "Default Model" setting in the user settings UI and API. Users can now explicitly set their default model to "None" (for automatic selection), and the UI will clearly indicate if the current default model is unavailable. The changes ensure proper support for null/empty values throughout the frontend, backend, and documentation, and improve type safety.

**User Settings UI Enhancements:**

- Added a "None" option as the first item in the default model dropdown, allowing users to opt for automatic model selection. Selecting "None" sets the default model to `null`.
- The display now shows "(Not available)" if the current default model is not among the available models.
- Updated state management and TypeScript types to support `string | null` for the default model, preventing UI inconsistencies and errors. [[1]](diffhunk://#diff-6b8f98e4fd73fc0c7c3b8b32685762eaa859d8850b45b3c757b493d041c80248L22-R22) [[2]](diffhunk://#diff-be18794ff3b3e083c648e32ff7a8b2a1378ecdc1fb3f98367429379d0dd64b2cL77-R78) [[3]](diffhunk://#diff-6b8f98e4fd73fc0c7c3b8b32685762eaa859d8850b45b3c757b493d041c80248L116-R116)

**API and Backend Updates:**

- The `/api/user/data` endpoint now accepts and stores `null` or empty string values for `default_model`, enabling "None" selection and proper validation. Invalid model IDs are rejected. [[1]](diffhunk://#diff-ad07c043c2608620829721f5421fdf6cbac599dd67a47a4eaf9424edb8d31826L131-R137) [[2]](diffhunk://#diff-ad07c043c2608620829721f5421fdf6cbac599dd67a47a4eaf9424edb8d31826L74-R74) [[3]](diffhunk://#diff-ad07c043c2608620829721f5421fdf6cbac599dd67a47a4eaf9424edb8d31826L223-R224)
- Documented new API behavior and added usage examples for setting the default model to "None" or handling invalid model IDs. [[1]](diffhunk://#diff-262179e87ebe074f913539357d7b430928f902bdaee5d731c3dcaaa88f9db1c9R112-R137) [[2]](diffhunk://#diff-262179e87ebe074f913539357d7b430928f902bdaee5d731c3dcaaa88f9db1c9R163-R165) [[3]](diffhunk://#diff-262179e87ebe074f913539357d7b430928f902bdaee5d731c3dcaaa88f9db1c9R221-R235) [[4]](diffhunk://#diff-262179e87ebe074f913539357d7b430928f902bdaee5d731c3dcaaa88f9db1c9R324-R346)

**Documentation Improvements:**

- Updated user settings and API documentation to describe the new "None" option, model availability indicators, and best practices for managing the default model. [[1]](diffhunk://#diff-ec33699ce7e33e105b8b74e137ae7bee2acdf485de418901f59c06a9ecf93131L63-R68) [[2]](diffhunk://#diff-ec33699ce7e33e105b8b74e137ae7bee2acdf485de418901f59c06a9ecf93131L116-R125) [[3]](diffhunk://#diff-ec8b38d4ce089c25eca66b89be1aceb7f426c62f8bcc457c741f7eb411e42a9bR70-R72) [[4]](diffhunk://#diff-ec8b38d4ce089c25eca66b89be1aceb7f426c62f8bcc457c741f7eb411e42a9bR114-R143) [[5]](diffhunk://#diff-ec8b38d4ce089c25eca66b89be1aceb7f426c62f8bcc457c741f7eb411e42a9bR220-R240)
- Added an issue/analysis file summarizing the problem, implementation plan, and exit criteria for null/empty default model handling.

**Type Safety:**

- All relevant types now explicitly support `string | null` for `default_model`, ensuring consistency across the codebase.

**References:**  
[[1]](diffhunk://#diff-6b8f98e4fd73fc0c7c3b8b32685762eaa859d8850b45b3c757b493d041c80248L22-R22) [[2]](diffhunk://#diff-6b8f98e4fd73fc0c7c3b8b32685762eaa859d8850b45b3c757b493d041c80248L116-R116) [[3]](diffhunk://#diff-6b8f98e4fd73fc0c7c3b8b32685762eaa859d8850b45b3c757b493d041c80248L256-R264) [[4]](diffhunk://#diff-6b8f98e4fd73fc0c7c3b8b32685762eaa859d8850b45b3c757b493d041c80248L306-R322) [[5]](diffhunk://#diff-be18794ff3b3e083c648e32ff7a8b2a1378ecdc1fb3f98367429379d0dd64b2cL77-R78) [[6]](diffhunk://#diff-ad07c043c2608620829721f5421fdf6cbac599dd67a47a4eaf9424edb8d31826L74-R74) [[7]](diffhunk://#diff-ad07c043c2608620829721f5421fdf6cbac599dd67a47a4eaf9424edb8d31826L131-R137) [[8]](diffhunk://#diff-ad07c043c2608620829721f5421fdf6cbac599dd67a47a4eaf9424edb8d31826L223-R224) [[9]](diffhunk://#diff-262179e87ebe074f913539357d7b430928f902bdaee5d731c3dcaaa88f9db1c9R112-R137) [[10]](diffhunk://#diff-262179e87ebe074f913539357d7b430928f902bdaee5d731c3dcaaa88f9db1c9R163-R165) [[11]](diffhunk://#diff-262179e87ebe074f913539357d7b430928f902bdaee5d731c3dcaaa88f9db1c9R221-R235) [[12]](diffhunk://#diff-262179e87ebe074f913539357d7b430928f902bdaee5d731c3dcaaa88f9db1c9R324-R346) [[13]](diffhunk://#diff-ec33699ce7e33e105b8b74e137ae7bee2acdf485de418901f59c06a9ecf93131L63-R68) [[14]](diffhunk://#diff-ec33699ce7e33e105b8b74e137ae7bee2acdf485de418901f59c06a9ecf93131L116-R125) [[15]](diffhunk://#diff-ec8b38d4ce089c25eca66b89be1aceb7f426c62f8bcc457c741f7eb411e42a9bR70-R72) [[16]](diffhunk://#diff-ec8b38d4ce089c25eca66b89be1aceb7f426c62f8bcc457c741f7eb411e42a9bR114-R143) [[17]](diffhunk://#diff-ec8b38d4ce089c25eca66b89be1aceb7f426c62f8bcc457c741f7eb411e42a9bR220-R240) [[18]](diffhunk://#diff-45502f702f944612b90bccdf7989403f55667b48a273d42b957a548389388d4cR1-R156)