### PR TITLE
docs: add usage and admin API documentation

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -59,6 +59,8 @@ These endpoints require user authentication and implement full rate limiting:
 - [`/api/chat/clear-all`](./chat-clear-all.md) - Bulk conversation deletion
 - [`/api/chat/sync`](./chat-sync.md) - Conversation synchronization
 - [`/api/user/data`](./user-data-endpoint.md) - User data and preferences
+- [`/api/usage/costs`](./usage-costs.md) - Token usage and cost records
+- [`/api/usage/costs/daily`](./usage-costs-daily.md) - Daily aggregated usage costs
 
 ### 🔄 Enhanced Endpoints (Optional Authentication)
 
@@ -71,7 +73,9 @@ These endpoints work for both anonymous and authenticated users with graceful de
 
 ### 🔐 Admin & Internal Endpoints
 
-- `/api/admin/sync-models` — protected via `withAdminAuth`
+- [`/api/admin/model-access`](./admin-model-access.md) — protected via `withAdminAuth`
+- [`/api/admin/users`](./admin-users.md) — protected via `withAdminAuth`
+- [`/api/admin/sync-models`](./admin-sync-models.md) — protected via `withAdminAuth`
 - `/api/internal/sync-models` — internal-only (Bearer or HMAC)
   - See: [internal-sync-models.md](./internal-sync-models.md)
 

--- a/docs/api/admin-model-access.md
+++ b/docs/api/admin-model-access.md
@@ -1,0 +1,48 @@
+# Endpoint: `/api/admin/model-access`
+
+Administrative management of model access records.
+
+**Methods:** `GET`, `PATCH`
+
+## Authentication & Authorization
+
+- **Admin Only**: Wrapped with `withAdminAuth` middleware.
+- **Rate Limiting**: Tier-based limits applied automatically.
+
+## Description
+
+- **GET**: Lists `model_access` rows with optional status filtering and pagination. Passing `meta=statuses` returns a list of distinct status values.
+- **PATCH**: Batch updates status or tier flags (`is_free`, `is_pro`, `is_enterprise`) for specified models via the `update_model_tier_access` RPC. Successful updates are audit logged.
+
+## Query Parameters (GET)
+
+- `status` – filter by status (`new`, `active`, `disabled`, `inactive`, `all`).
+- `limit` – number of records to return (default `100`, max `500`).
+- `offset` – pagination offset.
+- `meta=statuses` – return only distinct statuses.
+
+## Request Body (PATCH)
+
+```json
+{
+  "updates": [
+    {
+      "model_id": "gpt-4",
+      "status": "active",
+      "is_pro": true
+    }
+  ]
+}
+```
+
+## Response
+
+GET responds with `{ success: true, items, totalCount, filteredCount }`.
+PATCH responds with `{ success, results: [{ model_id, success, error? }] }` and may return status `200`, `207`, or `400` depending on individual update results.
+
+## Error Responses
+
+- `401 Unauthorized` if admin authentication fails.
+- `400 Bad Request` for invalid filters or update payloads.
+- `500 Internal Server Error` for unexpected failures.
+

--- a/docs/api/admin-users.md
+++ b/docs/api/admin-users.md
@@ -1,0 +1,51 @@
+# Endpoint: `/api/admin/users`
+
+Administrative search and bulk update operations for user profiles.
+
+**Methods:** `GET`, `PATCH`
+
+## Authentication & Authorization
+
+- **Admin Only**: Wrapped with `withAdminAuth` middleware.
+- **Rate Limiting**: Tier-based limits applied automatically.
+
+## Description
+
+- **GET**: Searches and lists user profiles with optional text search, tier/account-type filters, and pagination. `meta=filters` returns available tier and account type values.
+- **PATCH**: Batch updates subscription tier, account type, or credits for specified users. Tier changes are applied via the `update_user_tier` RPC and successful updates are audit logged.
+
+## Query Parameters (GET)
+
+- `q` – search string for email or name.
+- `tier` – filter by subscription tier (`free`, `pro`, `enterprise`, `all`).
+- `account_type` – filter by account type (`user`, `admin`, `all`).
+- `limit` – number of records to return (default `50`, max `200`).
+- `offset` – pagination offset.
+- `meta=filters` – return available filter values.
+
+## Request Body (PATCH)
+
+```json
+{
+  "updates": [
+    {
+      "id": "user-uuid",
+      "subscription_tier": "pro",
+      "account_type": "user",
+      "credits": 1000
+    }
+  ]
+}
+```
+
+## Response
+
+GET responds with `{ success: true, items, totalCount, filteredCount }`.
+PATCH responds with `{ success, results: [{ id, success, error? }] }` and may return status `200`, `207`, or `400` depending on individual update results.
+
+## Error Responses
+
+- `401 Unauthorized` if admin authentication fails.
+- `400 Bad Request` for invalid parameters or update payloads.
+- `500 Internal Server Error` for unexpected failures.
+

--- a/docs/api/usage-costs-daily.md
+++ b/docs/api/usage-costs-daily.md
@@ -1,0 +1,55 @@
+# Endpoint: `/api/usage/costs/daily`
+
+Provides daily aggregated token usage and cost totals for the authenticated user.
+
+**Method:** `GET`
+
+## Authentication & Authorization
+
+- **Authentication Required**: Uses `withProtectedAuth` middleware.
+- **Rate Limiting**: Tier-based limits applied automatically.
+
+## Description
+
+Aggregates token usage and costs by day for a given date range. Each item represents a day with token counts, cost, and assistant message count, plus overall totals for the range.
+
+## Query Parameters
+
+- `range` – `today`, `7d` (default), `30d`, or `custom`.
+- `start`, `end` – required when `range=custom` (format `YYYY-MM-DD`).
+- `model_id` – optional model filter.
+
+## Response
+
+```json
+{
+  "items": [
+    {
+      "usage_date": "2025-08-07",
+      "prompt_tokens": 0,
+      "completion_tokens": 0,
+      "total_tokens": 0,
+      "total_cost": 0,
+      "assistant_messages": 0
+    }
+  ],
+  "summary": {
+    "prompt_tokens": 0,
+    "completion_tokens": 0,
+    "total_tokens": 0,
+    "total_cost": 0
+  },
+  "range": {
+    "start": "2025-08-01",
+    "end": "2025-08-07",
+    "key": "7d"
+  }
+}
+```
+
+## Error Responses
+
+- `401 Unauthorized` if authentication fails.
+- `400 Bad Request` for invalid date ranges.
+- `500 Internal Server Error` for unexpected failures.
+

--- a/docs/api/usage-costs.md
+++ b/docs/api/usage-costs.md
@@ -1,0 +1,74 @@
+# Endpoint: `/api/usage/costs`
+
+Fetches token usage and cost records for the authenticated user.
+
+**Method:** `GET`
+
+## Authentication & Authorization
+
+- **Authentication Required**: Uses `withProtectedAuth` middleware.
+- **Rate Limiting**: Tier-based limits applied automatically.
+- Users only see their own usage data.
+
+## Description
+
+Returns detailed token usage and cost entries over a specified date range. Supports model filtering and pagination, and includes aggregated totals and top model statistics.
+
+## Query Parameters
+
+- `range` – `today`, `7d` (default), `30d`, or `custom`.
+- `start`, `end` – required when `range=custom` (format `YYYY-MM-DD`).
+- `model_id` – optional model filter.
+- `page` – page number (default `1`).
+- `page_size` – items per page (default `50`, max `200`).
+
+## Response
+
+```json
+{
+  "items": [
+    {
+      "assistant_message_id": "msg-id",
+      "session_id": "session-id",
+      "model_id": "model",
+      "message_timestamp": "2025-08-01T12:00:00Z",
+      "prompt_tokens": 0,
+      "completion_tokens": 0,
+      "total_tokens": 0,
+      "prompt_cost": 0,
+      "completion_cost": 0,
+      "image_cost": 0,
+      "total_cost": 0
+    }
+  ],
+  "pagination": {
+    "page": 1,
+    "page_size": 50,
+    "total": 0,
+    "total_pages": 1
+  },
+  "summary": {
+    "prompt_tokens": 0,
+    "completion_tokens": 0,
+    "total_tokens": 0,
+    "total_cost": 0,
+    "cost_per_1k": 0,
+    "top_models": {
+      "by_tokens": [],
+      "by_cost": []
+    }
+  },
+  "range": {
+    "start": "2025-08-01",
+    "end": "2025-08-07",
+    "key": "7d"
+  }
+}
+```
+
+## Error Responses
+
+- `401 Unauthorized` if authentication fails.
+- `400 Bad Request` for invalid parameters.
+- `500 Internal Server Error` for unexpected failures.
+


### PR DESCRIPTION
## Summary
- document `/api/usage/costs` and `/api/usage/costs/daily`
- document `/api/admin/model-access` and `/api/admin/users`
- reference new endpoints in API overview

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_689b2fd162848332904fc10c209fa16a