### PR TITLE
Feature/trigger sync not detecting new status

### DIFF
--- a/.github/todo.md
+++ b/.github/todo.md
@@ -5,7 +5,7 @@ Chatbot todo:
 - [x] Is active handling, remove is_active in db, client side cache for conversation/messages/is_active
 - [x] Chat messages is streaming db
 - [ ] Conversation syncing brainstorm, multi-sessions, multi-device, account sharing.. etc
-- [ ] Admin analytics, models usage, users usage, chat messages errors, new users sign up
+- [x] Admin analytics, models usage, users usage, chat messages errors, new users sign up
 - [ ] Anonymous user’s usage and analytics is not tracked.
 - [x] Attachments toast error when > ATTACHMENT_CAP
 - [x] Remove attachment without hover on mobile

--- a/.github/todo.md
+++ b/.github/todo.md
@@ -15,7 +15,7 @@ Chatbot todo:
 - [x] Console and terminal logs clean up, use logger.debug instead of console.log?
 - [ ] Landing page
 - [ ] Stripe payment? Account upgrade, billing.
-- [ ] Model sync not properly detecting “new” models.
+- [x] Model sync not properly detecting “new” models.
 - [ ] Upload images migration to UploadThings?
 - [ ] Brainstorm tokens/request. Very hard to estimate and enforce especially with reasoning, attachments, web search etc
 - [ ] Proper supabase setup, local + GitHub integration + supabase mcp?

--- a/backlog/trigger-sync-not-detecting-new-status.md
+++ b/backlog/trigger-sync-not-detecting-new-status.md
@@ -36,10 +36,11 @@ Observed: The Models tab in Admin Analytics shows New = 0 consistently, and the 
 - UI: `src/app/admin/AnalyticsPanel.tsx` → Models tab renders `ModelsResponse.recent` with columns New/Active/Inactive/Disabled/Total. Screenshot shows 0 for New across many days.
 - API: `src/app/api/admin/analytics/models/route.ts` fetches 2 sources:
   - `v_model_counts_public` for aggregate counts.
-  - `v_model_recent_activity_admin` for daily recent activity.
+  - (Deprecated) `v_model_recent_activity_admin` for daily recent activity.
+  - Replaced by `v_model_sync_activity_daily` which aggregates per-day sync metrics from `model_sync_log`.
 - DB views (schema): `database/schema/04-system.sql`
   - `v_model_counts_public`: counts current rows in `model_access` grouped by status.
-  - `v_model_recent_activity_admin`: groups by `DATE_TRUNC('day', updated_at)` and counts by `status` using FILTER. This counts the final status of rows that were updated on each day.
+  - `v_model_sync_activity_daily`: groups by `DATE_TRUNC('day', run_started_at)` in `model_sync_log` and sums `models_added`, `models_marked_inactive`, `models_reactivated` for completed runs.
 
 Therefore:
 
@@ -52,7 +53,7 @@ Therefore:
 - Expected creations vs analytics daily "New":
   1. Compare created vs daily flagged_new for a specific date (replace $DAY):
      - Creations: `SELECT COUNT(*) FROM public.model_access WHERE created_at::date = $DAY;`
-     - View: `SELECT flagged_new FROM v_model_recent_activity_admin WHERE day::date = $DAY;`
+  - View: `SELECT models_added FROM v_model_sync_activity_daily WHERE day::date = $DAY;`
   2. If the first query is > 0 and the second is 0, that confirms the mismatch.
 - Check if newly inserted rows quickly change status:
   - `SELECT model_id, status, created_at, updated_at FROM public.model_access WHERE created_at::date = $DAY ORDER BY updated_at DESC LIMIT 50;`
@@ -116,7 +117,7 @@ Therefore:
 
 - [ ] Add a new admin view `v_models_added_30d` grouped by `DATE_TRUNC('day', created_at)`.
 - [ ] Update `/api/admin/analytics/models` to also return `recent_added`.
-- [ ] Update UI to map the "New" column from `recent_added` while keeping the other columns from `v_model_recent_activity_admin`.
+- [x] Update UI to use `v_model_sync_activity_daily` (Added/Inactive/Reactivated per day) and compute daily total.
 - [ ] Tests: add a small DB test or mock verifying insert→same-day status flip still shows New=1 for that day.
 - [ ] Build passes and manual smoke test on Admin Analytics.
 - [ ] User verification: confirm "New" shows non-zero on days with known additions.

--- a/backlog/trigger-sync-not-detecting-new-status.md
+++ b/backlog/trigger-sync-not-detecting-new-status.md
@@ -2,6 +2,30 @@
 
 Observed: The Models tab in Admin Analytics shows New = 0 consistently, and the "Recent changes (30d)" table shows 0 in the New column across days, despite OpenRouter adding new models in the last two weeks. Trigger sync is working and inserts rows into `model_access` with `status = 'new'` initially, but the analytics-derived "modelsAdded" appears to remain 0.
 
+## Response details
+
+```json
+{
+  "success": true,
+  "message": "Model synchronization completed successfully",
+  "data": {
+    "syncLogId": "ecf0b99f-b5f4-4d27-80a8-68af2ece3918",
+    "totalProcessed": 323,
+    "modelsAdded": 0,
+    "modelsUpdated": 323,
+    "modelsMarkedInactive": 0,
+    "durationMs": 0,
+    "triggeredBy": "f319ca56-4197-477c-92e7-e6e2d95884be",
+    "triggeredAt": "2025-09-02T03:07:52.450Z"
+  },
+  "previousSync": {
+    "lastSyncAt": "2025-09-01T17:12:32.445Z",
+    "lastSyncStatus": "completed",
+    "lastSyncDuration": 0
+  }
+}
+```
+
 ## TL;DR hypothesis
 
 - The analytics view counts final status among rows updated on a given day (by `updated_at`), not transitions or creations. If a model is inserted as `new` and then immediately updated to `active`/`disabled` in the same sync cycle (or later the same day), the final status on that day is not `new`, so the daily "New" count remains 0. Similarly, the top-level "New" metric we surface likely reflects current status counts, not "newly added" counts.

--- a/database/README.md
+++ b/database/README.md
@@ -22,7 +22,7 @@ Canonical SQL lives in `database/schema/`. Run these files in order from the Sup
 What this creates (high level):
 
 - Tables: `profiles`, `chat_sessions`, `chat_messages`, `model_access`, `user_activity_log`, `user_usage_daily`, `model_sync_log`, `admin_audit_log`, `system_cache`, `system_stats`
-- Views: `api_user_summary`, `v_sync_stats`, `v_model_counts_public`, `v_model_recent_activity_admin`
+- Views: `api_user_summary`, `v_sync_stats`, `v_model_counts_public`, `v_model_sync_activity_daily`
 - RLS: Enabled on user-facing tables with safe SECURITY DEFINER helpers
 - Triggers: Profile sync from `auth.users`, chat session stats maintenance
 
@@ -104,7 +104,7 @@ See `database/schema/*` for detailed DDL. Highlights:
 - Main: `public.profiles`, `public.chat_sessions`, `public.chat_messages`, `public.model_access`
 - Analytics/Audit: `public.user_activity_log`, `public.user_usage_daily`, `public.model_sync_log`, `public.admin_audit_log`
 - System: `public.system_cache`, `public.system_stats`
-- Views: `public.api_user_summary`, `public.v_sync_stats`, `public.v_model_counts_public`, `public.v_model_recent_activity_admin`
+- Views: `public.api_user_summary`, `public.v_sync_stats`, `public.v_model_counts_public`, `public.v_model_sync_activity_daily`
 
 RLS and Triggers are defined inline in the schema files. SECURITY DEFINER functions are intended for server-side use.
 

--- a/database/patches/trigger-sync-not-detecting-new-status/001_fix_models_added_count.sql
+++ b/database/patches/trigger-sync-not-detecting-new-status/001_fix_models_added_count.sql
@@ -1,0 +1,195 @@
+-- 001_fix_models_added_count.sql
+-- Purpose: Fix models_added count in sync_openrouter_models by reliably distinguishing INSERT vs UPDATE
+-- Context: FOUND after INSERT ... ON CONFLICT DO UPDATE is true for both paths, so added count remained 0.
+-- Approach: Use UPDATE-first with ROW_COUNT; if 0 rows updated, perform INSERT. Keep reactivation logic based on previous_status.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.sync_openrouter_models(
+    models_data JSONB,
+    p_added_by_user_id UUID DEFAULT NULL
+)
+RETURNS JSONB AS $$
+DECLARE
+    model_record JSONB;
+    sync_log_id UUID;
+    count_models_added INTEGER := 0;
+    count_models_updated INTEGER := 0;
+    count_models_marked_inactive INTEGER := 0;
+    count_models_reactivated INTEGER := 0;
+    total_models INTEGER;
+    start_time TIMESTAMPTZ := NOW();
+    current_model_ids TEXT[];
+    previous_status VARCHAR(20);
+    updated_rows INTEGER;
+BEGIN
+    -- Start sync log with attribution
+    INSERT INTO public.model_sync_log (sync_status, total_openrouter_models, added_by_user_id)
+    VALUES ('running', jsonb_array_length(models_data), p_added_by_user_id)
+    RETURNING id INTO sync_log_id;
+
+    -- Get total count
+    total_models := jsonb_array_length(models_data);
+
+    -- Collect all current model IDs from OpenRouter
+    SELECT array_agg(model_element->>'id') INTO current_model_ids
+    FROM jsonb_array_elements(models_data) AS model_element;
+
+    -- Process each model from OpenRouter
+    FOR model_record IN SELECT * FROM jsonb_array_elements(models_data)
+    LOOP
+        -- Capture previous status (if any) for reactivation tracking
+        SELECT status INTO previous_status
+        FROM public.model_access
+        WHERE model_id = model_record->>'id';
+
+        -- Try UPDATE first; preserves tier flags and handles inactive->new transition
+        UPDATE public.model_access
+        SET
+            canonical_slug = model_record->>'canonical_slug',
+            hugging_face_id = model_record->>'hugging_face_id',
+            model_name = model_record->>'name',
+            model_description = model_record->>'description',
+            context_length = COALESCE((model_record->>'context_length')::integer, 8192),
+            modality = model_record->'architecture'->>'modality',
+            input_modalities = COALESCE(model_record->'architecture'->'input_modalities', '[]'::jsonb),
+            output_modalities = COALESCE(model_record->'architecture'->'output_modalities', '[]'::jsonb),
+            tokenizer = model_record->'architecture'->>'tokenizer',
+            prompt_price = COALESCE(model_record->'pricing'->>'prompt', '0'),
+            completion_price = COALESCE(model_record->'pricing'->>'completion', '0'),
+            request_price = COALESCE(model_record->'pricing'->>'request', '0'),
+            image_price = COALESCE(model_record->'pricing'->>'image', '0'),
+            web_search_price = COALESCE(model_record->'pricing'->>'web_search', '0'),
+            internal_reasoning_price = COALESCE(model_record->'pricing'->>'internal_reasoning', '0'),
+            input_cache_read_price = model_record->'pricing'->>'input_cache_read',
+            input_cache_write_price = model_record->'pricing'->>'input_cache_write',
+            max_completion_tokens = (model_record->'top_provider'->>'max_completion_tokens')::integer,
+            is_moderated = COALESCE((model_record->'top_provider'->>'is_moderated')::boolean, false),
+            supported_parameters = COALESCE(model_record->'supported_parameters', '[]'::jsonb),
+            openrouter_last_seen = NOW(),
+            last_synced_at = NOW(),
+            status = CASE
+                WHEN previous_status = 'inactive' THEN 'new'
+                WHEN previous_status = 'disabled' THEN 'disabled'
+                ELSE status
+            END,
+            updated_at = NOW()
+        WHERE model_id = model_record->>'id';
+
+        GET DIAGNOSTICS updated_rows = ROW_COUNT;
+
+        IF updated_rows > 0 THEN
+            -- It was an update
+            count_models_updated := count_models_updated + 1;
+            IF previous_status = 'inactive' THEN
+                count_models_reactivated := count_models_reactivated + 1;
+            END IF;
+        ELSE
+            -- No existing row; perform INSERT
+            INSERT INTO public.model_access (
+                model_id,
+                canonical_slug,
+                hugging_face_id,
+                model_name,
+                model_description,
+                context_length,
+                created_timestamp,
+                modality,
+                input_modalities,
+                output_modalities,
+                tokenizer,
+                prompt_price,
+                completion_price,
+                request_price,
+                image_price,
+                web_search_price,
+                internal_reasoning_price,
+                input_cache_read_price,
+                input_cache_write_price,
+                max_completion_tokens,
+                is_moderated,
+                supported_parameters,
+                openrouter_last_seen,
+                last_synced_at
+            ) VALUES (
+                model_record->>'id',
+                model_record->>'canonical_slug',
+                model_record->>'hugging_face_id',
+                model_record->>'name',
+                model_record->>'description',
+                COALESCE((model_record->>'context_length')::integer, 8192),
+                COALESCE((model_record->>'created')::bigint, extract(epoch from now())::bigint),
+                model_record->'architecture'->>'modality',
+                COALESCE(model_record->'architecture'->'input_modalities', '[]'::jsonb),
+                COALESCE(model_record->'architecture'->'output_modalities', '[]'::jsonb),
+                model_record->'architecture'->>'tokenizer',
+                COALESCE(model_record->'pricing'->>'prompt', '0'),
+                COALESCE(model_record->'pricing'->>'completion', '0'),
+                COALESCE(model_record->'pricing'->>'request', '0'),
+                COALESCE(model_record->'pricing'->>'image', '0'),
+                COALESCE(model_record->'pricing'->>'web_search', '0'),
+                COALESCE(model_record->'pricing'->>'internal_reasoning', '0'),
+                model_record->'pricing'->>'input_cache_read',
+                model_record->'pricing'->>'input_cache_write',
+                (model_record->'top_provider'->>'max_completion_tokens')::integer,
+                COALESCE((model_record->'top_provider'->>'is_moderated')::boolean, false),
+                COALESCE(model_record->'supported_parameters', '[]'::jsonb),
+                NOW(),
+                NOW()
+            );
+
+            count_models_added := count_models_added + 1;
+        END IF;
+    END LOOP;
+
+    -- Mark models as inactive if they're no longer in OpenRouter
+    UPDATE public.model_access
+    SET status = 'inactive', updated_at = NOW()
+    WHERE model_id NOT IN (SELECT unnest(current_model_ids))
+      AND status != 'inactive';
+
+    GET DIAGNOSTICS count_models_marked_inactive = ROW_COUNT;
+
+    -- Complete sync log
+    UPDATE public.model_sync_log
+    SET
+        sync_status = 'completed',
+        sync_completed_at = NOW(),
+        models_added = count_models_added,
+        models_updated = count_models_updated,
+        models_marked_inactive = count_models_marked_inactive,
+        models_reactivated = count_models_reactivated,
+        duration_ms = EXTRACT(EPOCH FROM (NOW() - start_time)) * 1000
+    WHERE id = sync_log_id;
+
+    RETURN jsonb_build_object(
+        'success', true,
+        'sync_log_id', sync_log_id,
+        'total_processed', total_models,
+        'models_added', count_models_added,
+        'models_updated', count_models_updated,
+        'models_marked_inactive', count_models_marked_inactive,
+        'models_reactivated', count_models_reactivated,
+        'duration_ms', EXTRACT(EPOCH FROM (NOW() - start_time)) * 1000
+    );
+
+EXCEPTION WHEN OTHERS THEN
+    -- Log error
+    UPDATE public.model_sync_log
+    SET
+        sync_status = 'failed',
+        sync_completed_at = NOW(),
+        error_message = SQLERRM,
+        error_details = jsonb_build_object('sqlstate', SQLSTATE),
+        duration_ms = EXTRACT(EPOCH FROM (NOW() - start_time)) * 1000
+    WHERE id = sync_log_id;
+
+    RETURN jsonb_build_object(
+        'success', false,
+        'error', SQLERRM,
+        'sync_log_id', sync_log_id
+    );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+COMMIT;

--- a/database/patches/trigger-sync-not-detecting-new-status/002_model_sync_activity_view.sql
+++ b/database/patches/trigger-sync-not-detecting-new-status/002_model_sync_activity_view.sql
@@ -1,0 +1,21 @@
+-- 002_model_sync_activity_view.sql
+-- Purpose: Provide daily aggregates for model sync activity based on model_sync_log
+-- Outputs (last 30 days): day, models_added, models_marked_inactive, models_reactivated, runs
+-- Security: Inherits RLS from underlying table; admin-only via model_sync_log policies
+
+BEGIN;
+
+CREATE OR REPLACE VIEW public.v_model_sync_activity_daily AS
+SELECT
+  DATE_TRUNC('day', COALESCE(sync_completed_at, sync_started_at)) AS day,
+  SUM(models_added) AS models_added,
+  SUM(models_marked_inactive) AS models_marked_inactive,
+  SUM(models_reactivated) AS models_reactivated,
+  COUNT(*) AS runs
+FROM public.model_sync_log
+WHERE sync_status = 'completed'
+  AND COALESCE(sync_completed_at, sync_started_at) >= NOW() - INTERVAL '30 days'
+GROUP BY 1
+ORDER BY day DESC;
+
+COMMIT;

--- a/database/patches/trigger-sync-not-detecting-new-status/003_drop_legacy_recent_activity_view.sql
+++ b/database/patches/trigger-sync-not-detecting-new-status/003_drop_legacy_recent_activity_view.sql
@@ -1,0 +1,9 @@
+-- Drop legacy view now replaced by v_model_sync_activity_daily
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_views WHERE schemaname = 'public' AND viewname = 'v_model_recent_activity_admin'
+  ) THEN
+    EXECUTE 'DROP VIEW public.v_model_recent_activity_admin';
+  END IF;
+END $$;

--- a/docs/admin/analytics.md
+++ b/docs/admin/analytics.md
@@ -10,14 +10,14 @@ This page describes the available analytics aggregates and how to use them in th
   - runs_24h, failures_24h
 - v_model_counts_public (safe for public)
   - new_count, active_count, inactive_count, disabled_count, total_count
-- v_model_recent_activity_admin (admin only)
+- v_model_sync_activity_daily (admin only)
   - day, flagged_new, flagged_active, flagged_inactive, flagged_disabled (last 30 days)
 
 ## Usage
 
 - Display v_sync_stats on the Admin Analytics tab as quick KPIs.
 - Use v_model_counts_public to show model status distribution (safe to show anywhere).
-- Use v_model_recent_activity_admin to chart rolling activity for the last 30 days.
+- Use v_model_sync_activity_daily to chart rolling activity for the last 30 days.
 
 ## Security & RLS
 
@@ -42,7 +42,7 @@ See details and response shapes in `docs/api/admin-analytics.md`.
 
 ## Semantics note on "New" (Models)
 
-`v_model_recent_activity_admin` groups by `updated_at` day and counts final status among rows updated that day. This means daily "New" does not necessarily equal models added that day. If inserts are flipped to active/disabled within the same day, "New" can read as 0. Tracked in `backlog/trigger-sync-not-detecting-new-status.md` with proposed fixes (count by `created_at` or add a status-transition history).
+`v_model_sync_activity_daily` aggregates per-day sums from `model_sync_log` over the last 30 days: models_added, models_marked_inactive, models_reactivated. This reflects actual sync job results rather than final statuses by updated_at.
 
 ## Audit log (admin_audit_log)
 

--- a/docs/api/admin-analytics.md
+++ b/docs/api/admin-analytics.md
@@ -118,7 +118,7 @@ Notes
 GET /api/admin/analytics/models
 
 - Purpose: Model portfolio counts + recent activity
-- Sources: `v_model_counts_public`, `v_model_recent_activity_admin`
+- Sources: `v_model_counts_public`, `v_model_sync_activity_daily`
 - Query params
   - none
 - Response

--- a/docs/ops/supabase-setup.md
+++ b/docs/ops/supabase-setup.md
@@ -20,7 +20,7 @@ Run the four schema files from the repo in this order (Dashboard → SQL Editor)
 What you get:
 
 - Tables: profiles, chat_sessions, chat_messages, model_access, user_activity_log, user_usage_daily, model_sync_log, admin_audit_log, system_cache, system_stats
-- Views: api_user_summary, v_sync_stats, v_model_counts_public, v_model_recent_activity_admin
+- Views: api_user_summary, v_sync_stats, v_model_counts_public, v_model_sync_activity_daily
 - RLS policies + triggers
 
 ## 2) Create the storage bucket

--- a/src/app/admin/AnalyticsPanel.tsx
+++ b/src/app/admin/AnalyticsPanel.tsx
@@ -56,7 +56,7 @@ function RangePicker({ value, onChange }: { value: RangeKey; onChange: (v: Range
   interface UsageDay { date: string; active_users: number; messages: number; tokens: number }
   interface UsageResponse { ok: boolean; total_messages: number; daily: UsageDay[] }
   interface ModelsCounts { total_count: number; new_count: number; active_count: number; inactive_count: number; disabled_count: number }
-  interface ModelsRecent { day: string; flagged_new: number; flagged_active: number; flagged_inactive: number; flagged_disabled: number }
+  interface ModelsRecent { day: string; models_added: number; models_marked_inactive: number; models_reactivated: number }
   interface ModelsResponse { ok: boolean; counts: ModelsCounts; recent: ModelsRecent[] }
 
   // Tab components (fetch only when mounted)
@@ -288,7 +288,7 @@ function RangePicker({ value, onChange }: { value: RangeKey; onChange: (v: Range
             <div className="p-3 border rounded-md"><div className="text-xs text-gray-500">Inactive</div><div className="text-xl font-semibold">{models.data.counts?.inactive_count ?? 0}</div></div>
             <div className="p-3 border rounded-md"><div className="text-xs text-gray-500">Disabled</div><div className="text-xl font-semibold">{models.data.counts?.disabled_count ?? 0}</div></div>
             <div className="md:col-span-5 p-3 border rounded-md">
-              <div className="text-xs text-gray-500">Recent changes (30d)</div>
+        <div className="text-xs text-gray-500">Recent changes (30d)</div>
               {(() => {
                 // Sort most recent first for quick scanning
                 const recentSorted = [...(models.data?.recent || [])].sort((a, b) => b.day.localeCompare(a.day));
@@ -299,26 +299,24 @@ function RangePicker({ value, onChange }: { value: RangeKey; onChange: (v: Range
                       <thead className="text-gray-500">
                         <tr>
                           <th className="text-left font-medium py-1 pr-2">Date</th>
-                          <th className="text-right font-medium py-1 pr-2">New</th>
-                          <th className="text-right font-medium py-1 pr-2">Active</th>
-                          <th className="text-right font-medium py-1 pr-2">Inactive</th>
-                          <th className="text-right font-medium py-1 pr-2">Disabled</th>
+              <th className="text-right font-medium py-1 pr-2">Added</th>
+              <th className="text-right font-medium py-1 pr-2">Inactive</th>
+              <th className="text-right font-medium py-1 pr-2">Reactivated</th>
                           <th className="text-right font-medium py-1">Total</th>
                         </tr>
                       </thead>
                       <tbody>
                         {recentSorted.map((r: ModelsRecent) => {
-                          const total = r.flagged_new + r.flagged_active + r.flagged_inactive + r.flagged_disabled;
+              const total = (r.models_added || 0) + (r.models_marked_inactive || 0) + (r.models_reactivated || 0);
                           const cell = (val: number) => (
                             <span className={val === 0 ? 'text-gray-400' : 'font-semibold'}>{val}</span>
                           );
                           return (
                             <tr key={r.day} className="border-t border-gray-100 dark:border-gray-800">
                               <td className="py-1 pr-2 font-mono text-gray-700 dark:text-gray-300" title={r.day}>{fmtIsoDate(r.day)}</td>
-                              <td className="py-1 pr-2 text-right">{cell(r.flagged_new)}</td>
-                              <td className="py-1 pr-2 text-right">{cell(r.flagged_active)}</td>
-                              <td className="py-1 pr-2 text-right">{cell(r.flagged_inactive)}</td>
-                              <td className="py-1 pr-2 text-right">{cell(r.flagged_disabled)}</td>
+                <td className="py-1 pr-2 text-right">{cell(r.models_added)}</td>
+                <td className="py-1 pr-2 text-right">{cell(r.models_marked_inactive)}</td>
+                <td className="py-1 pr-2 text-right">{cell(r.models_reactivated)}</td>
                               <td className="py-1 text-right">{cell(total)}</td>
                             </tr>
                           );

--- a/src/app/api/admin/analytics/models/route.ts
+++ b/src/app/api/admin/analytics/models/route.ts
@@ -14,13 +14,16 @@ async function handler(_req: NextRequest, auth: AuthContext) {
     const supabase = await createClient();
     const [countsRes, recentRes] = await Promise.all([
       supabase.from('v_model_counts_public').select('*').limit(1),
-      supabase.from('v_model_recent_activity_admin').select('*').order('day', { ascending: true })
+      supabase
+        .from('v_model_sync_activity_daily')
+        .select('day, models_added, models_marked_inactive, models_reactivated')
+        .order('day', { ascending: true })
     ]);
 
     return NextResponse.json({
       ok: true,
       counts: (countsRes.data && countsRes.data[0]) || { total_count: 0, new_count: 0, active_count: 0, inactive_count: 0, disabled_count: 0 },
-      recent: recentRes.data || []
+  recent: recentRes.data || []
     });
   } catch (err) {
     logger.error('admin.analytics.models error', err);


### PR DESCRIPTION
This pull request fixes the "models_added" count in admin analytics by updating the model sync logic and associated analytics views. The main change is to reliably distinguish between new model inserts and updates during synchronization, ensuring new models are correctly counted and surfaced in analytics. It also replaces the legacy daily activity view with a new, more accurate aggregation and updates documentation and API/UI references.

**Model sync logic improvements:**

* Refactored the `sync_openrouter_models` function to use an UPDATE-first approach and only INSERT when no row is updated, reliably tracking new model additions and reactivations. The function now correctly increments `models_added` and related counters for admin analytics. [[1]](diffhunk://#diff-5484dec199323a08f2b77a5a23eb8d53771f4a1fbf9efeec37f824ae69b9b7feR1-R195) [[2]](diffhunk://#diff-c250d5090f0efe4fa2b74ab5a5f2b26a18cade234e487977ca7afd032e45f0f2R243)

**Analytics view and API updates:**

* Added a new view `v_model_sync_activity_daily` to aggregate daily sync metrics (`models_added`, `models_marked_inactive`, `models_reactivated`) for the last 30 days, replacing the legacy view.
* Dropped the legacy `v_model_recent_activity_admin` view, updating all API and documentation references to use `v_model_sync_activity_daily` instead. [[1]](diffhunk://#diff-29093c06f29485da9ce4be28d600563dca2209e1d24f0e0ca0d326363de9df30R1-R9) [[2]](diffhunk://#diff-f8e505b3338b27b64aded9fbb280ce3d8d21c719f57dbc7c31f6087b17dfb834L35-R35) [[3]](diffhunk://#diff-f8e505b3338b27b64aded9fbb280ce3d8d21c719f57dbc7c31f6087b17dfb834L77-R77) [[4]](diffhunk://#diff-f8e505b3338b27b64aded9fbb280ce3d8d21c719f57dbc7c31f6087b17dfb834L280-R280) [[5]](diffhunk://#diff-f8e505b3338b27b64aded9fbb280ce3d8d21c719f57dbc7c31f6087b17dfb834L492-R492) [[6]](diffhunk://#diff-f8e505b3338b27b64aded9fbb280ce3d8d21c719f57dbc7c31f6087b17dfb834L526-R530) [[7]](diffhunk://#diff-fd576aa9849805f8c7caa810a765c78f6eca90b612bd369f90d4a88d2357e3d8L25-R25) [[8]](diffhunk://#diff-fd576aa9849805f8c7caa810a765c78f6eca90b612bd369f90d4a88d2357e3d8L107-R107)

**Admin analytics and UI fixes:**

* Updated the admin analytics API and UI to use the new daily activity view, ensuring the "New" column in the models table now reflects actual new model additions per day. [[1]](diffhunk://#diff-8d88bb02f4ece7ffc9abef9fb43a6e92ac777be08443226e7c419e5b64622ba8L15-R43) [[2]](diffhunk://#diff-8d88bb02f4ece7ffc9abef9fb43a6e92ac777be08443226e7c419e5b64622ba8L31-R56) [[3]](diffhunk://#diff-8d88bb02f4ece7ffc9abef9fb43a6e92ac777be08443226e7c419e5b64622ba8L95-R120)

**Documentation and backlog updates:**

* Updated `.github/todo.md` to mark the admin analytics and model sync bug as completed. [[1]](diffhunk://#diff-1ba6b42c5b057136d28db62930875d9edc20a5ec3b017c7975d72cc205e7957fL8-R8) [[2]](diffhunk://#diff-1ba6b42c5b057136d28db62930875d9edc20a5ec3b017c7975d72cc205e7957fL18-R18)
* Added details and response examples to the troubleshooting backlog for model sync analytics.

These changes ensure that new model additions are accurately tracked and displayed in admin analytics, resolving prior issues where new models were not counted due to status transitions during sync.