### PR TITLE
added missing migration patch for auth profile sync

### DIFF
--- a/backlog/db_dump_analysis_functions.md
+++ b/backlog/db_dump_analysis_functions.md
@@ -1,0 +1,181 @@
+# DB Dump Analysis – Functions
+
+## Summary
+
+- Total function declarations under `database/schema`: **110** across seven module files plus the `000_baseline.sql` snapshot.
+- Application-owned modules (`01-` through `07-`) contribute **42** concrete functions, all of which are represented in `supabase/migrations/`.
+- Exactly **20** helper functions are missing from the migrations snapshot; every one of them lives in `000_baseline.sql` and belongs to Supabase-managed domains (auth JWT helper and storage RPC utilities) that Supabase CLI omits when dumping.
+
+### Missing function coverage
+
+| Function                                        | Declared in        |
+| ----------------------------------------------- | ------------------ |
+| `auth.jwt`                                      | `000_baseline.sql` |
+| `storage.add_prefixes`                          | `000_baseline.sql` |
+| `storage.can_insert_object`                     | `000_baseline.sql` |
+| `storage.delete_prefix`                         | `000_baseline.sql` |
+| `storage.delete_prefix_hierarchy_trigger`       | `000_baseline.sql` |
+| `storage.enforce_bucket_name_length`            | `000_baseline.sql` |
+| `storage.filename`                              | `000_baseline.sql` |
+| `storage.foldername`                            | `000_baseline.sql` |
+| `storage.get_level`                             | `000_baseline.sql` |
+| `storage.get_prefix`                            | `000_baseline.sql` |
+| `storage.get_prefixes`                          | `000_baseline.sql` |
+| `storage.get_size_by_bucket`                    | `000_baseline.sql` |
+| `storage.list_multipart_uploads_with_delimiter` | `000_baseline.sql` |
+| `storage.list_objects_with_delimiter`           | `000_baseline.sql` |
+| `storage.objects_insert_prefix_trigger`         | `000_baseline.sql` |
+| `storage.objects_update_prefix_trigger`         | `000_baseline.sql` |
+| `storage.prefixes_insert_trigger`               | `000_baseline.sql` |
+| `storage.search_legacy_v1`                      | `000_baseline.sql` |
+| `storage.search_v1_optimised`                   | `000_baseline.sql` |
+| `storage.search_v2`                             | `000_baseline.sql` |
+
+> All missing functions are Supabase-managed helpers (auth JWT + storage RPCs). They are not exportable through `supabase db dump` and must be recreated manually if needed.
+
+## Coverage by schema file
+
+### `000_baseline.sql`
+
+| Function                                        | In migrations? |
+| ----------------------------------------------- | -------------- |
+| `auth.email`                                    | ✅             |
+| `auth.jwt`                                      | ❌             |
+| `auth.role`                                     | ✅             |
+| `auth.uid`                                      | ✅             |
+| `public._set_updated_at`                        | ✅             |
+| `public.analyze_database_health`                | ✅             |
+| `public.ban_user`                               | ✅             |
+| `public.calculate_and_record_message_cost`      | ✅             |
+| `public.can_user_use_model`                     | ✅             |
+| `public.cleanup_anonymous_errors`               | ✅             |
+| `public.cleanup_anonymous_usage`                | ✅             |
+| `public.cleanup_cta_events`                     | ✅             |
+| `public.cleanup_old_data`                       | ✅             |
+| `public.get_admin_user_model_costs_daily`       | ✅             |
+| `public.get_anonymous_errors`                   | ✅             |
+| `public.get_anonymous_model_costs`              | ✅             |
+| `public.get_error_count`                        | ✅             |
+| `public.get_global_model_costs`                 | ✅             |
+| `public.get_model_sync_activity_daily`          | ✅             |
+| `public.get_recent_errors`                      | ✅             |
+| `public.get_sync_stats`                         | ✅             |
+| `public.get_user_allowed_models`                | ✅             |
+| `public.get_user_complete_profile`              | ✅             |
+| `public.get_user_model_costs_daily`             | ✅             |
+| `public.get_user_recent_sessions`               | ✅             |
+| `public.handle_user_profile_sync`               | ✅             |
+| `public.ingest_anonymous_error`                 | ✅             |
+| `public.ingest_anonymous_usage`                 | ✅             |
+| `public.ingest_cta_event`                       | ✅             |
+| `public.is_admin`                               | ✅             |
+| `public.is_banned`                              | ✅             |
+| `public.log_user_activity`                      | ✅             |
+| `public.on_chat_attachment_link_recompute`      | ✅             |
+| `public.protect_ban_columns`                    | ✅             |
+| `public.recompute_image_cost_for_user_message`  | ✅             |
+| `public.sync_openrouter_models`                 | ✅             |
+| `public.track_session_creation`                 | ✅             |
+| `public.track_user_usage`                       | ✅             |
+| `public.unban_user`                             | ✅             |
+| `public.update_model_tier_access`               | ✅             |
+| `public.update_session_stats`                   | ✅             |
+| `public.update_session_timestamp`               | ✅             |
+| `public.update_updated_at_column`               | ✅             |
+| `public.update_user_tier`                       | ✅             |
+| `public.write_admin_audit`                      | ✅             |
+| `storage.add_prefixes`                          | ❌             |
+| `storage.can_insert_object`                     | ❌             |
+| `storage.delete_prefix`                         | ❌             |
+| `storage.delete_prefix_hierarchy_trigger`       | ❌             |
+| `storage.enforce_bucket_name_length`            | ❌             |
+| `storage.extension`                             | ✅             |
+| `storage.filename`                              | ❌             |
+| `storage.foldername`                            | ❌             |
+| `storage.get_level`                             | ❌             |
+| `storage.get_prefix`                            | ❌             |
+| `storage.get_prefixes`                          | ❌             |
+| `storage.get_size_by_bucket`                    | ❌             |
+| `storage.list_multipart_uploads_with_delimiter` | ❌             |
+| `storage.list_objects_with_delimiter`           | ❌             |
+| `storage.objects_insert_prefix_trigger`         | ❌             |
+| `storage.objects_update_prefix_trigger`         | ❌             |
+| `storage.operation`                             | ✅             |
+| `storage.prefixes_insert_trigger`               | ❌             |
+| `storage.search`                                | ✅             |
+| `storage.search_legacy_v1`                      | ❌             |
+| `storage.search_v1_optimised`                   | ❌             |
+| `storage.search_v2`                             | ❌             |
+| `storage.update_updated_at_column`              | ✅             |
+
+### `01-users.sql`
+
+| Function                           | In migrations? |
+| ---------------------------------- | -------------- |
+| `public.ban_user`                  | ✅             |
+| `public.get_user_complete_profile` | ✅             |
+| `public.handle_user_profile_sync`  | ✅             |
+| `public.is_admin`                  | ✅             |
+| `public.is_banned`                 | ✅             |
+| `public.log_user_activity`         | ✅             |
+| `public.protect_ban_columns`       | ✅             |
+| `public.track_user_usage`          | ✅             |
+| `public.unban_user`                | ✅             |
+| `public.update_updated_at_column`  | ✅             |
+| `public.update_user_tier`          | ✅             |
+
+### `02-chat.sql`
+
+| Function                                       | In migrations? |
+| ---------------------------------------------- | -------------- |
+| `public.calculate_and_record_message_cost`     | ✅             |
+| `public.get_admin_user_model_costs_daily`      | ✅             |
+| `public.get_error_count`                       | ✅             |
+| `public.get_global_model_costs`                | ✅             |
+| `public.get_recent_errors`                     | ✅             |
+| `public.get_user_model_costs_daily`            | ✅             |
+| `public.get_user_recent_sessions`              | ✅             |
+| `public.on_chat_attachment_link_recompute`     | ✅             |
+| `public.recompute_image_cost_for_user_message` | ✅             |
+| `public.track_session_creation`                | ✅             |
+| `public.update_session_stats`                  | ✅             |
+| `public.update_session_timestamp`              | ✅             |
+
+### `03-models.sql`
+
+| Function                          | In migrations? |
+| --------------------------------- | -------------- |
+| `public.can_user_use_model`       | ✅             |
+| `public.get_sync_stats`           | ✅             |
+| `public.get_user_allowed_models`  | ✅             |
+| `public.sync_openrouter_models`   | ✅             |
+| `public.update_model_tier_access` | ✅             |
+
+### `04-system.sql`
+
+| Function                               | In migrations? |
+| -------------------------------------- | -------------- |
+| `public.analyze_database_health`       | ✅             |
+| `public.cleanup_cta_events`            | ✅             |
+| `public.cleanup_old_data`              | ✅             |
+| `public.get_model_sync_activity_daily` | ✅             |
+| `public.ingest_cta_event`              | ✅             |
+| `public.write_admin_audit`             | ✅             |
+
+### `06-anonymous.sql`
+
+| Function                           | In migrations? |
+| ---------------------------------- | -------------- |
+| `public._set_updated_at`           | ✅             |
+| `public.cleanup_anonymous_errors`  | ✅             |
+| `public.cleanup_anonymous_usage`   | ✅             |
+| `public.get_anonymous_errors`      | ✅             |
+| `public.get_anonymous_model_costs` | ✅             |
+| `public.ingest_anonymous_error`    | ✅             |
+| `public.ingest_anonymous_usage`    | ✅             |
+
+### `07-stripe-payments.sql`
+
+| Function                | In migrations? |
+| ----------------------- | -------------- |
+| `public.set_updated_at` | ✅             |

--- a/backlog/db_dump_analysis_policies.md
+++ b/backlog/db_dump_analysis_policies.md
@@ -1,0 +1,145 @@
+# DB Dump Analysis – Policies
+## Summary
+
+- Unique policy declarations under `database/schema`: **104** across seven module files plus the `000_baseline.sql` snapshot.
+- Every policy definition is present in `supabase/migrations/`.
+- Supabase-managed policies (profiles, storage, auth) appear both in the baseline dump and in their module-specific files; duplication is expected.
+
+> No gaps detected: migrations recreate all row level security policies from the schema dump.
+
+### `000_baseline.sql`
+| Policy | Table | In migrations? |
+| --- | --- | --- |
+| `Admin can read CTA events` | `"public"."cta_events"` | ✅ |
+| `Admins can insert moderation actions` | `"public"."moderation_actions"` | ✅ |
+| `Admins can insert sync logs` | `"public"."model_sync_log"` | ✅ |
+| `Admins can read anonymous errors` | `"public"."anonymous_error_events"` | ✅ |
+| `Admins can read anonymous model usage` | `"public"."anonymous_model_usage_daily"` | ✅ |
+| `Admins can read anonymous usage` | `"public"."anonymous_usage_daily"` | ✅ |
+| `Admins can update moderation actions` | `"public"."moderation_actions"` | ✅ |
+| `Admins can update sync logs` | `"public"."model_sync_log"` | ✅ |
+| `Admins can view moderation actions` | `"public"."moderation_actions"` | ✅ |
+| `All users can view model access` | `"public"."model_access"` | ✅ |
+| `Allow inserts from server roles` | `"public"."cta_events"` | ✅ |
+| `Deny direct deletes` | `"public"."anonymous_model_usage_daily"` | ✅ |
+| `Deny direct deletes` | `"public"."anonymous_usage_daily"` | ✅ |
+| `Deny direct updates` | `"public"."anonymous_model_usage_daily"` | ✅ |
+| `Deny direct updates` | `"public"."anonymous_usage_daily"` | ✅ |
+| `Deny direct writes` | `"public"."anonymous_model_usage_daily"` | ✅ |
+| `Deny direct writes` | `"public"."anonymous_usage_daily"` | ✅ |
+| `Deny error deletes` | `"public"."anonymous_error_events"` | ✅ |
+| `Deny error updates` | `"public"."anonymous_error_events"` | ✅ |
+| `Deny error writes` | `"public"."anonymous_error_events"` | ✅ |
+| `Insert message costs` | `"public"."message_token_costs"` | ✅ |
+| `Insert via definer only` | `"public"."admin_audit_log"` | ✅ |
+| `Only admins can read audit logs` | `"public"."admin_audit_log"` | ✅ |
+| `Only admins can view sync logs` | `"public"."model_sync_log"` | ✅ |
+| `Update profiles` | `"public"."profiles"` | ✅ |
+| `Users can create messages in their sessions` | `"public"."chat_messages"` | ✅ |
+| `Users can create their own chat sessions` | `"public"."chat_sessions"` | ✅ |
+| `Users can delete messages in their sessions` | `"public"."chat_messages"` | ✅ |
+| `Users can delete their own attachments` | `"public"."chat_attachments"` | ✅ |
+| `Users can delete their own chat sessions` | `"public"."chat_sessions"` | ✅ |
+| `Users can delete their own message annotations` | `"public"."chat_message_annotations"` | ✅ |
+| `Users can insert their own attachments` | `"public"."chat_attachments"` | ✅ |
+| `Users can insert their own message annotations` | `"public"."chat_message_annotations"` | ✅ |
+| `Users can insert their own profile` | `"public"."profiles"` | ✅ |
+| `Users can insert their own usage` | `"public"."user_usage_daily"` | ✅ |
+| `Users can update messages in their sessions` | `"public"."chat_messages"` | ✅ |
+| `Users can update their own attachments` | `"public"."chat_attachments"` | ✅ |
+| `Users can update their own chat sessions` | `"public"."chat_sessions"` | ✅ |
+| `Users can update their own usage` | `"public"."user_usage_daily"` | ✅ |
+| `Users can view messages from their sessions` | `"public"."chat_messages"` | ✅ |
+| `Users can view their own activity` | `"public"."user_activity_log"` | ✅ |
+| `Users can view their own attachments` | `"public"."chat_attachments"` | ✅ |
+| `Users can view their own chat sessions` | `"public"."chat_sessions"` | ✅ |
+| `Users can view their own message annotations` | `"public"."chat_message_annotations"` | ✅ |
+| `Users can view their own usage` | `"public"."user_usage_daily"` | ✅ |
+| `View message costs` | `"public"."message_token_costs"` | ✅ |
+| `View profiles` | `"public"."profiles"` | ✅ |
+| `attachments-images: delete own` | `"storage"."objects"` | ✅ |
+| `attachments-images: insert own` | `"storage"."objects"` | ✅ |
+| `attachments-images: read own` | `"storage"."objects"` | ✅ |
+| `attachments-images: update own` | `"storage"."objects"` | ✅ |
+
+### `01-users.sql`
+| Policy | Table | In migrations? |
+| --- | --- | --- |
+| `View profiles` | `public.profiles` | ✅ |
+| `Update profiles` | `public.profiles` | ✅ |
+| `Users can insert their own profile` | `public.profiles` | ✅ |
+| `Users can view their own activity` | `public.user_activity_log` | ✅ |
+| `Users can view their own usage` | `public.user_usage_daily` | ✅ |
+| `Users can insert their own usage` | `public.user_usage_daily` | ✅ |
+| `Users can update their own usage` | `public.user_usage_daily` | ✅ |
+| `Admins can view moderation actions` | `public.moderation_actions` | ✅ |
+| `Admins can insert moderation actions` | `public.moderation_actions` | ✅ |
+| `Admins can update moderation actions` | `public.moderation_actions` | ✅ |
+
+### `02-chat.sql`
+| Policy | Table | In migrations? |
+| --- | --- | --- |
+| `Users can view their own chat sessions` | `public.chat_sessions` | ✅ |
+| `Users can create their own chat sessions` | `public.chat_sessions` | ✅ |
+| `Users can update their own chat sessions` | `public.chat_sessions` | ✅ |
+| `Users can delete their own chat sessions` | `public.chat_sessions` | ✅ |
+| `Users can view messages from their sessions` | `public.chat_messages` | ✅ |
+| `Users can create messages in their sessions` | `public.chat_messages` | ✅ |
+| `Users can update messages in their sessions` | `public.chat_messages` | ✅ |
+| `Users can delete messages in their sessions` | `public.chat_messages` | ✅ |
+| `Users can view their own attachments` | `public.chat_attachments` | ✅ |
+| `Users can insert their own attachments` | `public.chat_attachments` | ✅ |
+| `Users can update their own attachments` | `public.chat_attachments` | ✅ |
+| `Users can delete their own attachments` | `public.chat_attachments` | ✅ |
+| `Users can view their own message annotations` | `public.chat_message_annotations` | ✅ |
+| `Users can insert their own message annotations` | `public.chat_message_annotations` | ✅ |
+| `Users can delete their own message annotations` | `public.chat_message_annotations` | ✅ |
+| `View message costs` | `public.message_token_costs` | ✅ |
+| `Insert message costs` | `public.message_token_costs` | ✅ |
+
+### `03-models.sql`
+| Policy | Table | In migrations? |
+| --- | --- | --- |
+| `All users can view model access` | `public.model_access` | ✅ |
+| `Only admins can view sync logs` | `public.model_sync_log` | ✅ |
+| `Admins can insert sync logs` | `public.model_sync_log` | ✅ |
+| `Admins can update sync logs` | `public.model_sync_log` | ✅ |
+
+### `04-system.sql`
+| Policy | Table | In migrations? |
+| --- | --- | --- |
+| `Only admins can read audit logs` | `public.admin_audit_log` | ✅ |
+| `Insert via definer only` | `public.admin_audit_log` | ✅ |
+| `Admin can read CTA events` | `public.cta_events` | ✅ |
+| `Allow inserts from server roles` | `public.cta_events` | ✅ |
+
+### `05-storage.sql`
+| Policy | Table | In migrations? |
+| --- | --- | --- |
+| `attachments-images: read own` | `storage.objects` | ✅ |
+| `attachments-images: insert own` | `storage.objects` | ✅ |
+| `attachments-images: delete own` | `storage.objects` | ✅ |
+| `attachments-images: update own` | `storage.objects` | ✅ |
+
+### `06-anonymous.sql`
+| Policy | Table | In migrations? |
+| --- | --- | --- |
+| `Admins can read anonymous usage` | `public.anonymous_usage_daily` | ✅ |
+| `Deny direct writes` | `public.anonymous_usage_daily` | ✅ |
+| `Deny direct updates` | `public.anonymous_usage_daily` | ✅ |
+| `Deny direct deletes` | `public.anonymous_usage_daily` | ✅ |
+| `Admins can read anonymous model usage` | `public.anonymous_model_usage_daily` | ✅ |
+| `Deny direct writes` | `public.anonymous_model_usage_daily` | ✅ |
+| `Deny direct updates` | `public.anonymous_model_usage_daily` | ✅ |
+| `Deny direct deletes` | `public.anonymous_model_usage_daily` | ✅ |
+| `Admins can read anonymous errors` | `public.anonymous_error_events` | ✅ |
+| `Deny error writes` | `public.anonymous_error_events` | ✅ |
+| `Deny error updates` | `public.anonymous_error_events` | ✅ |
+| `Deny error deletes` | `public.anonymous_error_events` | ✅ |
+
+### `07-stripe-payments.sql`
+| Policy | Table | In migrations? |
+| --- | --- | --- |
+| `Users select own subscriptions` | `public.subscriptions` | ✅ |
+| `Users select own payments` | `public.payment_history` | ✅ |
+

--- a/backlog/db_dump_analysis_trigger.md
+++ b/backlog/db_dump_analysis_trigger.md
@@ -1,0 +1,31 @@
+# DB Dump Analysis – Trigger Coverage
+
+## Summary
+
+- Scanned every SQL file under `database/schema/` for `CREATE TRIGGER` statements.
+- Cross-checked each trigger name against the checked-in Supabase migrations under `supabase/migrations/`.
+- Identified which triggers are represented in migrations and which require manual backfill.
+
+## Trigger Inventory
+
+| Trigger name                           | Target table / schema                | Defined in schema file                   | Present in Supabase migrations?                                           |
+| -------------------------------------- | ------------------------------------ | ---------------------------------------- | ------------------------------------------------------------------------- |
+| `update_profiles_updated_at`           | `public.profiles`                    | `database/schema/01-users.sql`           | ✅ `supabase/migrations/20250912161250_remote_schema.sql`                 |
+| `on_auth_user_profile_sync`            | `auth.users`                         | `database/schema/01-users.sql`           | ✅ `supabase/migrations/20250927103000_add_auth_profile_sync_trigger.sql` |
+| `trg_protect_ban_columns`              | `public.profiles`                    | `database/schema/01-users.sql`           | ✅ `supabase/migrations/20250912161250_remote_schema.sql`                 |
+| `on_message_change`                    | `public.chat_messages`               | `database/schema/02-chat.sql`            | ✅ `supabase/migrations/20250912161250_remote_schema.sql`                 |
+| `on_session_updated`                   | `public.chat_sessions`               | `database/schema/02-chat.sql`            | ✅ `supabase/migrations/20250912161250_remote_schema.sql`                 |
+| `on_session_created`                   | `public.chat_sessions`               | `database/schema/02-chat.sql`            | ✅ `supabase/migrations/20250912161250_remote_schema.sql`                 |
+| `after_assistant_message_cost`         | `public.chat_messages`               | `database/schema/02-chat.sql`            | ✅ `supabase/migrations/20250912161250_remote_schema.sql`                 |
+| `after_attachment_link_recompute_cost` | `public.chat_attachments`            | `database/schema/02-chat.sql`            | ✅ `supabase/migrations/20250912161250_remote_schema.sql`                 |
+| `on_anonymous_usage_update`            | `public.anonymous_usage_daily`       | `database/schema/06-anonymous.sql`       | ✅ `supabase/migrations/20250912161250_remote_schema.sql`                 |
+| `on_anonymous_model_usage_update`      | `public.anonymous_model_usage_daily` | `database/schema/06-anonymous.sql`       | ✅ `supabase/migrations/20250912161250_remote_schema.sql`                 |
+| `trg_subscriptions_updated_at`         | `public.subscriptions`               | `database/schema/07-stripe-payments.sql` | ✅ `supabase/migrations/20250920093000_stripe_payments.sql`               |
+
+> **Note:** `database/schema/000_baseline.sql` duplicates most trigger definitions from the module-specific schema files, but the authoritative locations are listed above. Only `on_auth_user_profile_sync` failed to make it into the generated migration snapshot.
+
+## Gaps & Next Steps
+
+- [x] Create a migration that adds `on_auth_user_profile_sync` (plus its `handle_user_profile_sync` dependencies if needed) to ensure dev/prod stay consistent. (See `supabase/migrations/20250927103000_add_auth_profile_sync_trigger.sql`; deploy to apply.)
+- [ ] After deploying that migration, merge the patch back into `database/schema/000_baseline.sql` if you keep it as canonical reference.
+- [ ] Consider scripting the trigger/function extraction workflow so future changes to managed schemas (like `auth`) are less error-prone.

--- a/scripts/generate_policy_doc.py
+++ b/scripts/generate_policy_doc.py
@@ -1,0 +1,109 @@
+"""Utilities for generating markdown coverage reports for RLS policies.
+
+The script scans `database/schema/*.sql` for `CREATE POLICY` statements and
+compares them against the checked-in Supabase migrations. It rewrites
+`backlog/db_dump_analysis_policies.md` with a complete coverage table.
+"""
+
+import re
+from pathlib import Path
+from typing import List, Sequence, Tuple
+
+SCHEMA_DIR = Path("database/schema")
+MIGRATIONS_DIR = Path("supabase/migrations")
+OUTPUT_PATH = Path("backlog/db_dump_analysis_policies.md")
+
+POLICY_PATTERN = re.compile(
+    r"create\s+policy\s+(?:\"([^\"]+)\"|([\w-]+))\s+on\s+([\w\.\"]+)",
+    re.IGNORECASE,
+)
+
+
+def _read_migrations() -> str:
+    if not MIGRATIONS_DIR.exists():
+        return ""
+    return "\n".join(path.read_text() for path in MIGRATIONS_DIR.glob("*.sql"))
+
+
+def _collect_policy_rows(
+    migration_text: str,
+) -> Tuple[
+    List[Tuple[str, List[Tuple[str, str, bool]]]], int, List[Tuple[str, str, str]]
+]:
+    sections: List[Tuple[str, List[Tuple[str, str, bool]]]] = []
+    unique: set[Tuple[str, str]] = set()
+    missing: List[Tuple[str, str, str]] = []
+
+    for path in sorted(SCHEMA_DIR.glob("*.sql")):
+        text = path.read_text()
+        rows: List[Tuple[str, str, bool]] = []
+        for match in POLICY_PATTERN.finditer(text):
+            name = match.group(1) or match.group(2)
+            table = match.group(3)
+            key = (name, table)
+            unique.add(key)
+            name_pattern = re.compile(
+                rf"create\s+policy\s+\"?{re.escape(name)}\"?",
+                re.IGNORECASE,
+            )
+            in_migrations = bool(name_pattern.search(migration_text))
+            rows.append((name, table, in_migrations))
+            if not in_migrations:
+                missing.append((name, table, path.name))
+        sections.append((path.name, rows))
+
+    return sections, len(unique), missing
+
+
+def _render_table(rows: Sequence[Tuple[str, str, bool]]) -> List[str]:
+    lines = ["| Policy | Table | In migrations? |\n", "| --- | --- | --- |\n"]
+    for name, table, flag in rows:
+        status = "✅" if flag else "❌"
+        lines.append(f"| `{name}` | `{table}` | {status} |\n")
+    return lines
+
+
+def generate_policy_report(output_path: Path = OUTPUT_PATH) -> None:
+    migration_text = _read_migrations()
+    sections, unique_count, missing = _collect_policy_rows(migration_text)
+
+    lines: List[str] = []
+    lines.append("# DB Dump Analysis – Policies\n")
+    lines.append("## Summary\n\n")
+    lines.append(
+        f"- Unique policy declarations under `database/schema`: **{unique_count}** across seven module files plus the `000_baseline.sql` snapshot.\n"
+    )
+    if missing:
+        lines.append(
+            f"- Missing policy definitions in migrations: **{len(missing)}** (detailed below).\n"
+        )
+    else:
+        lines.append(
+            "- Every policy definition is present in `supabase/migrations/`.\n"
+        )
+    lines.append(
+        "- Supabase-managed policies (profiles, storage, auth) appear both in the baseline dump and in their module-specific files; duplication is expected.\n\n"
+    )
+
+    if missing:
+        lines.append("### Missing policy coverage\n\n")
+        lines.append("| Policy | Table | Declared in |\n")
+        lines.append("| --- | --- | --- |\n")
+        for name, table, filename in missing:
+            lines.append(f"| `{name}` | `{table}` | `{filename}` |\n")
+        lines.append("\n")
+    else:
+        lines.append(
+            "> No gaps detected: migrations recreate all row level security policies from the schema dump.\n\n"
+        )
+
+    for file_name, rows in sections:
+        lines.append(f"### `{file_name}`\n")
+        lines.extend(_render_table(rows))
+        lines.append("\n")
+
+    output_path.write_text("".join(lines), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    generate_policy_report()

--- a/scripts/policy_markdown.py
+++ b/scripts/policy_markdown.py
@@ -1,0 +1,7 @@
+"""Deprecated wrapper retained for compatibility.
+
+Prefer running ``scripts/generate_policy_doc.py`` which now owns the policy
+coverage analysis.
+"""
+
+raise SystemExit("Deprecated: run scripts/generate_policy_doc.py instead")

--- a/scripts/tmp_policy_summary.py
+++ b/scripts/tmp_policy_summary.py
@@ -1,0 +1,7 @@
+"""Deprecated helper retained for backwards compatibility.
+
+Use ``scripts/generate_policy_doc.py`` to build policy coverage reports.
+This placeholder exists so any stray references fail loudly with guidance.
+"""
+
+raise SystemExit("Deprecated: run scripts/generate_policy_doc.py instead")

--- a/supabase/migrations/20250927103000_add_auth_profile_sync_trigger.sql
+++ b/supabase/migrations/20250927103000_add_auth_profile_sync_trigger.sql
@@ -1,0 +1,121 @@
+-- Migration: Restore auth profile sync trigger
+-- Date: 2025-09-27
+-- Ensures auth.users changes continue to sync into public.profiles
+
+-- 1) Function (kept in sync with database/schema/01-users.sql)
+CREATE OR REPLACE FUNCTION public.handle_user_profile_sync()
+RETURNS TRIGGER AS $$
+DECLARE
+    last_sync_time TIMESTAMPTZ;
+    sync_threshold INTERVAL := '1 minute';
+    profile_email_before VARCHAR(255);
+    email_changed BOOLEAN := false;
+    profile_created_recently BOOLEAN := false;
+BEGIN
+    -- Check if profile already exists
+    IF EXISTS (SELECT 1 FROM public.profiles WHERE id = NEW.id) THEN
+        -- Get current profile email for comparison
+        SELECT email INTO profile_email_before
+        FROM public.profiles
+        WHERE id = NEW.id;
+
+        -- Check if email will change
+        email_changed := (profile_email_before != NEW.email);
+
+        -- Check if profile was created recently (within last 2 minutes)
+        -- This allows new users to get one profile_synced after profile_created
+        SELECT EXISTS(
+            SELECT 1 FROM public.user_activity_log
+            WHERE user_id = NEW.id
+            AND action = 'profile_created'
+            AND timestamp > NOW() - INTERVAL '2 minutes'
+        ) INTO profile_created_recently;
+
+        -- Check for recent sync to avoid duplicates
+        -- Always check for recent syncs, regardless of profile creation status
+        SELECT MAX(timestamp) INTO last_sync_time
+        FROM public.user_activity_log
+        WHERE user_id = NEW.id
+        AND action = 'profile_synced'
+        AND timestamp > NOW() - sync_threshold;
+
+        -- Profile exists, update with latest information from Google
+        UPDATE public.profiles SET
+            email = NEW.email,
+            full_name = COALESCE(
+                NEW.raw_user_meta_data->>'full_name',
+                NEW.raw_user_meta_data->>'name',
+                full_name,
+                split_part(NEW.email, '@', 1)
+            ),
+            avatar_url = COALESCE(
+                NEW.raw_user_meta_data->>'avatar_url',
+                avatar_url
+            ),
+            last_active = NOW(),
+            updated_at = NOW()
+        WHERE id = NEW.id;
+
+        -- Log the profile update only if:
+        -- 1. No recent sync occurred (within threshold), OR
+        -- 2. Email has changed (important changes should always be logged)
+        IF last_sync_time IS NULL OR email_changed THEN
+            PERFORM public.log_user_activity(
+                NEW.id,
+                'profile_synced',
+                'profile',
+                NEW.id::text,
+                jsonb_build_object(
+                    'email_updated', email_changed,
+                    'sync_source', 'google_oauth',
+                    'deduplication_applied', last_sync_time IS NOT NULL AND NOT email_changed,
+                    'new_user_sync', profile_created_recently
+                )
+            );
+        END IF;
+    ELSE
+        -- Profile doesn't exist, create new one
+        INSERT INTO public.profiles (id, email, full_name, avatar_url, last_active)
+        VALUES (
+            NEW.id,
+            NEW.email,
+            COALESCE(
+                NEW.raw_user_meta_data->>'full_name',
+                NEW.raw_user_meta_data->>'name',
+                split_part(NEW.email, '@', 1)
+            ),
+            NEW.raw_user_meta_data->>'avatar_url',
+            NOW()
+        );
+
+        -- Log the profile creation (always log new profile creation)
+        PERFORM public.log_user_activity(
+            NEW.id,
+            'profile_created',
+            'profile',
+            NEW.id::text,
+            jsonb_build_object(
+                'sync_source', 'google_oauth',
+                'created_from_oauth', true
+            )
+        );
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = 'pg_catalog, public';
+
+-- 2) Trigger recreation
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_trigger
+        WHERE tgname = 'on_auth_user_profile_sync'
+    ) THEN
+        EXECUTE 'DROP TRIGGER on_auth_user_profile_sync ON auth.users;';
+    END IF;
+
+    EXECUTE 'CREATE TRIGGER on_auth_user_profile_sync
+        AFTER INSERT OR UPDATE ON auth.users
+        FOR EACH ROW EXECUTE FUNCTION public.handle_user_profile_sync();';
+END $$;


### PR DESCRIPTION
This pull request introduces comprehensive analysis and documentation regarding Supabase database schema coverage, focusing on functions, policies, and triggers. It also updates the Supabase CLI workflow documentation to reflect the latest migration commands and best practices. The changes ensure better visibility into which schema objects are covered by migrations, highlight any gaps, and provide clear operational guidance for database changes.

**Schema analysis and coverage documentation:**

- Added `db_dump_analysis_functions.md` to document all function declarations under `database/schema`, identifying 20 Supabase-managed helper functions (auth JWT and storage RPCs) missing from migration snapshots and clarifying that these must be recreated manually if needed.
- Added `db_dump_analysis_policies.md` to inventory all row-level security policies, confirming that every policy in the schema is present in migrations and noting expected duplication for Supabase-managed domains.
- Added `db_dump_analysis_trigger.md` to catalog all triggers defined in the schema, cross-check their presence in migrations, and document the one trigger (`on_auth_user_profile_sync`) that required a manual migration to maintain consistency.

**Supabase CLI workflow documentation updates:**

- Updated `docs/ops/supabase-cli-guide.md` to use the new `supabase migration up` and `supabase migration deploy` commands instead of the deprecated `supabase db migrate up` and `supabase db push`. Added notes about the difference between migration-based workflows and schema-push, and included new commands for listing migration status.
- Expanded the CLI guide to provide a step-by-step promotion flow (local → dev → prod), clarifying the recommended process for preparing, testing, deploying, and verifying migrations across environments.