### PR TITLE
fix long press hint showing on chat interface

### DIFF
--- a/components/chat/ChatInterface.tsx
+++ b/components/chat/ChatInterface.tsx
@@ -230,6 +230,7 @@ export default function ChatInterface() {
           isOpen={true}
           onClose={() => {}} // Not used on desktop
           onNewChat={handleNewChat}
+          showMobileHint={false}
         />
       </div>
 

--- a/components/ui/ChatSidebar.tsx
+++ b/components/ui/ChatSidebar.tsx
@@ -17,9 +17,10 @@ interface ChatSidebarProps {
   onClose: () => void;
   onNewChat: () => void;
   className?: string;
+  showMobileHint?: boolean;
 }
 
-export function ChatSidebar({ isOpen, onClose, onNewChat, className = "" }: ChatSidebarProps) {
+export function ChatSidebar({ isOpen, onClose, onNewChat, className = "", showMobileHint = true }: ChatSidebarProps) {
   // Get conversation data from store
   const {
     conversations,
@@ -71,7 +72,7 @@ export function ChatSidebar({ isOpen, onClose, onNewChat, className = "" }: Chat
 
   // One-time discoverability hint for mobile/touch users when sidebar becomes visible
   useEffect(() => {
-    if (hasHover || !isOpen) return; // desktop or sidebar hidden
+    if (hasHover || !isOpen || !showMobileHint) return; // desktop or sidebar hidden
     try {
       const key = 'chatSidebar.longpress.hint.v1';
       if (!localStorage.getItem(key)) {
@@ -81,7 +82,7 @@ export function ChatSidebar({ isOpen, onClose, onNewChat, className = "" }: Chat
     } catch {
       // ignore storage errors
     }
-  }, [hasHover, isOpen]);
+  }, [hasHover, isOpen, showMobileHint]);
 
   // When the action sheet opens, ensure the target row is visible
   useEffect(() => {

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -61,6 +61,15 @@ function SignInInner() {
     }
   }, [target]);
 
+  const handleCancel = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+    setAutoRedirect(false);
+    router.back();
+  }, [router]);
+
   // Start/stop countdown timer
   useEffect(() => {
     // Clear any existing timer first
@@ -96,7 +105,7 @@ function SignInInner() {
   }, [seconds, autoRedirect, isAuthenticated, handleGoogle]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 px-4 sm:px-6 lg:px-8 py-8">
+    <div className="min-h-[var(--mobile-content-height)] sm:min-h-[var(--desktop-content-height)] flex items-center justify-center bg-gray-50 dark:bg-gray-900 px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
       <div className="w-full max-w-xl sm:max-w-2xl">
         <div className="bg-white/90 dark:bg-gray-800/80 backdrop-blur rounded-2xl shadow-md border border-gray-200/60 dark:border-gray-700 p-6 sm:p-10">
           <div className="text-center">
@@ -111,7 +120,7 @@ function SignInInner() {
                   You will be returned to <span className="font-mono text-gray-900 dark:text-gray-100">{target || "/chat"}</span> after signing in.
                 </>
               ) : (
-                <>Auto‑redirect paused. You can sign in now when you’re ready.</>
+                <>Redirect canceled. Returning to your previous page…</>
               )}
             </p>
           </div>
@@ -121,24 +130,13 @@ function SignInInner() {
               Continue with Google
             </Button>
             <div className="text-center text-xs sm:text-sm text-gray-500 dark:text-gray-400">
-              {autoRedirect ? (
+              {autoRedirect && (
                 <button
                   type="button"
-                  onClick={() => setAutoRedirect(false)}
+                  onClick={handleCancel}
                   className="underline hover:text-gray-700 dark:hover:text-gray-300"
                 >
-                  Cancel auto-redirect
-                </button>
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => {
-                    setSeconds(5);
-                    setAutoRedirect(true);
-                  }}
-                  className="underline hover:text-gray-700 dark:hover:text-gray-300"
-                >
-                  Restart 5s countdown
+                  Cancel
                 </button>
               )}
             </div>


### PR DESCRIPTION
This pull request introduces improvements to the chat sidebar's mobile hint logic and refines the sign-in page's redirect and cancel behavior. The main goals are to give finer control over when mobile hints are shown and to enhance user experience during the sign-in flow by clarifying and simplifying redirect cancellation.

**Chat Sidebar: Mobile Hint Control**

* Added a `showMobileHint` prop to the `ChatSidebar` component, allowing parent components to control whether the discoverability hint for mobile/touch users is displayed. The hint logic now respects this prop and updates its effect dependencies accordingly. (`components/ui/ChatSidebar.tsx`, `components/chat/ChatInterface.tsx`) [[1]](diffhunk://#diff-1845192aa8c687e122d12894c77c1256db76cc6a310ad269cd2efdfbfb2eae38R20-R23) [[2]](diffhunk://#diff-1845192aa8c687e122d12894c77c1256db76cc6a310ad269cd2efdfbfb2eae38L74-R75) [[3]](diffhunk://#diff-1845192aa8c687e122d12894c77c1256db76cc6a310ad269cd2efdfbfb2eae38L84-R85) [[4]](diffhunk://#diff-dce868dbf5a85d1bc5551145a06ccb96336437cb0d65f51059781a0901073d05R233)

**Sign-in Page: Redirect and Cancel Experience**

* Introduced a `handleCancel` callback that cancels the auto-redirect timer, resets related state, and navigates the user back to the previous page. (`src/app/auth/signin/page.tsx`)
* Updated the sign-in page UI and messaging to clarify when a redirect is canceled, replacing the "paused" state with a clear "Redirect canceled" message. (`src/app/auth/signin/page.tsx`)
* Simplified the cancel button logic: the button now cancels the redirect and returns the user, instead of toggling between cancel/restart. (`src/app/auth/signin/page.tsx`)
* Adjusted sign-in page layout for improved responsiveness and consistent spacing across devices. (`src/app/auth/signin/page.tsx`)