### PR TITLE
Document missing Google Search favicon

### DIFF
--- a/issues/google-search-missing-favicon.md
+++ b/issues/google-search-missing-favicon.md
@@ -6,7 +6,7 @@
 
 ## Evidence
 - `src/app/layout.tsx` registers only SVG favicon assets (`/favicon.svg`, `/favicon-16x16.svg`, `/favicon-32x32.svg`).
-- The `public/` directory does not contain a `/favicon.ico` or PNG/WebP fallback, so Google cannot fetch a supported raster favicon from the root domain.
+- The `public/` directory does not contain a `/favicon.ico` or PNG fallback, so Google cannot fetch a supported raster favicon from the root domain.
 
 ## Impact
 - Search result entries fall back to a generic globe icon instead of the brand artwork, reducing brand recognition in search listings.

--- a/issues/google-search-missing-favicon.md
+++ b/issues/google-search-missing-favicon.md
@@ -12,6 +12,18 @@
 - Search result entries fall back to a generic globe icon instead of the brand artwork, reducing brand recognition in search listings.
 
 ## Proposed Fix
-- Generate a raster favicon (ICO or PNG) and place it in `public/favicon.ico` (and optionally supply PNG sizes).
-- Reference the raster icon in the Next.js metadata so crawlers that ignore SVG favicons can pick it up.
+- Generate a raster favicon (ICO or PNG) and place it in `public/favicon.ico`. Optionally, supply PNG sizes (16x16, 32x32, 48x48) in the `public/` directory.
+- Reference the raster icons in the Next.js metadata so crawlers that ignore SVG favicons can pick them up. For example, in `src/app/layout.tsx`:
 
+  ```ts
+  export const metadata = {
+    icons: {
+      icon: [
+        { url: '/favicon.ico', sizes: 'any', type: 'image/x-icon' },
+        { url: '/favicon-16x16.png', sizes: '16x16', type: 'image/png' },
+        { url: '/favicon-32x32.png', sizes: '32x32', type: 'image/png' },
+        { url: '/favicon-48x48.png', sizes: '48x48', type: 'image/png' }
+      ],
+      apple: [{ url: '/apple-touch-icon.png', sizes: '180x180' }]
+    }
+  };

--- a/issues/google-search-missing-favicon.md
+++ b/issues/google-search-missing-favicon.md
@@ -1,0 +1,17 @@
+# Google Search results missing brand favicon
+
+## Summary
+- The brand favicon does not appear beside search results for the site.
+- Google Search looks for a raster `/favicon.ico` (or another supported raster icon) at the site root, but the app only publishes SVG favicon variants.
+
+## Evidence
+- `src/app/layout.tsx` registers only SVG favicon assets (`/favicon.svg`, `/favicon-16x16.svg`, `/favicon-32x32.svg`).
+- The `public/` directory does not contain a `/favicon.ico` or PNG/WebP fallback, so Google cannot fetch a supported raster favicon from the root domain.
+
+## Impact
+- Search result entries fall back to a generic globe icon instead of the brand artwork, reducing brand recognition in search listings.
+
+## Proposed Fix
+- Generate a raster favicon (ICO or PNG) and place it in `public/favicon.ico` (and optionally supply PNG sizes).
+- Reference the raster icon in the Next.js metadata so crawlers that ignore SVG favicons can pick it up.
+

--- a/issues/google-search-missing-favicon.md
+++ b/issues/google-search-missing-favicon.md
@@ -2,7 +2,7 @@
 
 ## Summary
 - The brand favicon does not appear beside search results for the site.
-- Google Search looks for a raster `/favicon.ico` (or another supported raster icon) at the site root, but the app only publishes SVG favicon variants.
+- Google Search and most crawlers require a raster favicon (ICO or PNG) and ignore SVG; ensure a 48×48+ PNG and/or `/favicon.ico` is available at the root or linked via `rel="icon"`.
 
 ## Evidence
 - `src/app/layout.tsx` registers only SVG favicon assets (`/favicon.svg`, `/favicon-16x16.svg`, `/favicon-32x32.svg`).


### PR DESCRIPTION
## Summary
- add an issue report capturing why the brand favicon is absent from Google Search results
- note that only SVG favicon assets are exposed and propose adding a raster `/favicon.ico`

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e20bc024b08332a22e2ad35b07f7cc