### PR TITLE
fix: force dynamic sitemap route

### DIFF
--- a/src/app/sitemap.xml/route.ts
+++ b/src/app/sitemap.xml/route.ts
@@ -1,5 +1,7 @@
 import { getModelCatalog } from "../../../lib/server/modelCatalog";
 
+export const dynamic = "force-dynamic";
+
 const baseUrl = (process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000").replace(/\/$/, "");
 
 const staticRoutes = [


### PR DESCRIPTION
This pull request introduces a small configuration change to the sitemap route. The route is now explicitly set as dynamic by adding the `dynamic = "force-dynamic"` export to `src/app/sitemap.xml/route.ts`. This ensures that the sitemap is always generated dynamically rather than being statically cached.